### PR TITLE
敵の数を制限

### DIFF
--- a/server/usecase/enemyUsecase.ts
+++ b/server/usecase/enemyUsecase.ts
@@ -7,6 +7,7 @@ let intervalId: NodeJS.Timeout | null = null;
 export const enemyUsecase = {
   init: () => {
     intervalId = setInterval(() => {
+      enemyUsecase.create();
       enemyUsecase.update();
     }, 500);
   },
@@ -16,12 +17,14 @@ export const enemyUsecase = {
       intervalId = null;
     }
   },
-  create: async (): Promise<EnemyModel | null> => {
+  create: async (): Promise<EnemyModel | null | undefined> => {
+    const count = await enemyRepository.count();
+    if (count > 3) return;
     const enemyData: EnemyModel = {
       enemyId: enemyIdParser.parse(randomUUID()),
-      pos: { x: 1000, y: 300 },
+      pos: { x: 1000, y: Math.floor(Math.random() * 800) },
       score: 100,
-      vector: { x: 5, y: 5 },
+      vector: { x: 25, y: 5 },
       type: 0,
     };
     await enemyRepository.save(enemyData);
@@ -53,7 +56,7 @@ export const enemyUsecase = {
   update: async () => {
     const currentEnemyInfos = await enemyRepository.findAll();
     const promises = currentEnemyInfos.map((enemy) => {
-      if (enemy.pos.x > 1920 || enemy.pos.y < 0) {
+      if (enemy.pos.x > 1920 || enemy.pos.x < 50) {
         return enemyUsecase.delete(enemy);
       } else {
         return enemyUsecase.move(enemy);


### PR DESCRIPTION
## 内容

・敵が自動生成される
・同時に存在する敵の数を4体にした。（敵の数は後から増やす予定）


## 変更点

・enemyusecaseのintervalにenemyUsecase.create()を追加。＜－敵を自動生成する
・enemyusecaseのcreateに敵の数を制限する部分を追加。

## 関連 Issue

close #49 

## スクリーンショット・動画など



https://github.com/INIAD-Developers/Gradius-2023/assets/131966441/af9ebf97-390f-4472-932f-8ee4f5080686


