### PR TITLE
当たり判定

### DIFF
--- a/server/service/app.ts
+++ b/server/service/app.ts
@@ -1,6 +1,7 @@
 import server from '$/$server';
 import { API_BASE_PATH, CORS_ORIGIN } from '$/service/envValues';
 import { bulletUsecase } from '$/usecase/bulletUsecase';
+import { collisionUsecase } from '$/usecase/collisionUsecase';
 import { enemyUsecase } from '$/usecase/enemyUsecase';
 import cookie from '@fastify/cookie';
 import cors from '@fastify/cors';
@@ -16,6 +17,7 @@ export const init = (serverFactory?: FastifyServerFactory) => {
   server(app, { basePath: API_BASE_PATH });
   bulletUsecase.init();
   enemyUsecase.init();
+  collisionUsecase.init();
 
   return app;
 };

--- a/server/tests/setup.ts
+++ b/server/tests/setup.ts
@@ -2,6 +2,7 @@ import { init } from '$/service/app';
 import { PORT } from '$/service/envValues';
 import { prismaClient } from '$/service/prismaClient';
 import { bulletUsecase } from '$/usecase/bulletUsecase';
+import { collisionUsecase } from '$/usecase/collisionUsecase';
 import { enemyUsecase } from '$/usecase/enemyUsecase';
 import { exec } from 'child_process';
 import type { FastifyInstance } from 'fastify';
@@ -26,6 +27,7 @@ afterEach(async (info) => {
   if (unneededServer(info.meta.file)) return;
 
   await prismaClient.$disconnect();
+  collisionUsecase.stop();
   enemyUsecase.stop();
   bulletUsecase.stop();
   await server.close();

--- a/server/usecase/collisionUsecase.ts
+++ b/server/usecase/collisionUsecase.ts
@@ -1,0 +1,49 @@
+import { bulletRepository } from '$/repository/bulletRepository';
+import { enemyRepository } from '$/repository/enemyRepository';
+import { playerRepository } from '$/repository/playerRepository';
+let intervalId: NodeJS.Timeout | null = null;
+export const collisionUsecase = {
+  init: () => {
+    intervalId = setInterval(() => {
+      collisionUsecase.checkCollisonPlayerAndEnemy();
+      collisionUsecase.checkCollisonBulletAndEnemy();
+    }, 500);
+  },
+  stop: () => {
+    if (intervalId) {
+      clearInterval(intervalId);
+      intervalId = null;
+    }
+  },
+  //playerとenemyのあたり判定
+  checkCollisonPlayerAndEnemy: async () => {
+    const currentPlayerInfo = await playerRepository.findAll();
+    const currentEnemyInfo = await enemyRepository.findAll();
+    currentPlayerInfo.forEach((player) => {
+      currentEnemyInfo.forEach((enemy) => {
+        const distanceSquared =
+          (player.pos.x - enemy.pos.x) ** 2 + (player.pos.y - enemy.pos.y) ** 2;
+        if (distanceSquared < 10000) {
+          console.log('bbbb');
+          enemyRepository.delete(enemy.enemyId);
+        }
+      });
+    });
+  },
+  //bulletとenemyのあたり判定
+  checkCollisonBulletAndEnemy: async () => {
+    const currentBulletInfo = await bulletRepository.findAll();
+    const currentEnemyInfo = await enemyRepository.findAll();
+    currentBulletInfo.forEach((bullet) => {
+      currentEnemyInfo.forEach((enemy) => {
+        const distanceSquared =
+          (bullet.pos.x - enemy.pos.x) ** 2 + (bullet.pos.y - enemy.pos.y) ** 2;
+        if (distanceSquared < 5000) {
+          console.log('bbbb');
+          enemyRepository.delete(enemy.enemyId);
+          bulletRepository.delete(bullet.bulletId);
+        }
+      });
+    });
+  },
+};

--- a/server/usecase/enemyUsecase.ts
+++ b/server/usecase/enemyUsecase.ts
@@ -7,9 +7,9 @@ let intervalId: NodeJS.Timeout | null = null;
 export const enemyUsecase = {
   init: () => {
     intervalId = setInterval(() => {
-      // enemyUsecase.create();
-      // enemyUsecase.update();
-    }, 75);
+      enemyUsecase.create();
+      enemyUsecase.update();
+    }, 500);
   },
   stop: () => {
     if (intervalId) {


### PR DESCRIPTION
## 内容

プレイヤーと敵、弾と敵、の当たり判定を作った。

## 変更点

・collisionUsecaseを作り、そこに当たり判定を行う関数を作成。
・各プレイヤーと敵の距離を三平方の定理（c^2＝a^2 + b^2）で計算してc^2 が 10,000以下になったとき、
  敵を削除するようにした。（後々、衝突したらスコアを減らすなどに変える予定）
・各弾と敵の距離を三平方の定理（c^2＝a^2 + b^2）で計算してc^2 が 5,000以下になったとき、
  弾と敵を削除するようにした。

## 関連 Issue

#42 

## スクリーンショット・動画など



https://github.com/INIAD-Developers/Gradius-2023/assets/131966441/5e1a949e-bb01-481e-9f16-32bb10f2a6a4


## その他

当たり判定は四分木空間分割などの実装出来ていないことがあるため、issueはcloseしません。
