### PR TITLE
当たり判定の実装

### DIFF
--- a/client/src/pages/game/index.page.tsx
+++ b/client/src/pages/game/index.page.tsx
@@ -88,9 +88,6 @@ const Game = () => {
           {bullets.map((bullet) => (
             <Circle x={bullet.pos.x} y={bullet.pos.y} radius={7} fill="red" key={bullet.bulletId} />
           ))}
-          {effectPosition.map((position, index) => (
-            <Boom position={position} key={index} />
-          ))}
         </Layer>
         <Layer>
           {players.map((player) => (
@@ -115,6 +112,11 @@ const Game = () => {
               y={enemy.pos.y - 40}
               key={enemy.enemyId}
             />
+          ))}
+        </Layer>
+        <Layer>
+          {effectPosition.map((position, index) => (
+            <Boom position={position} key={index} />
           ))}
         </Layer>
       </Stage>

--- a/client/src/pages/game/index.page.tsx
+++ b/client/src/pages/game/index.page.tsx
@@ -99,7 +99,7 @@ const Game = () => {
               width={100}
               height={100}
               rotation={player.side === 'left' ? 90 : -90}
-              x={player.pos.x - 50}
+              x={player.pos.x + 50}
               y={player.pos.y - 50}
               key={player.userId}
             />

--- a/server/repository/bulletRepository.ts
+++ b/server/repository/bulletRepository.ts
@@ -65,16 +65,12 @@ export const bulletRepository = {
     return bullets.map(toBulletModel);
   },
   delete: async (bulletId: BulletId) => {
-    const bullet = await prismaClient.bullet.findUnique({
-      where: {
-        bulletId,
-      },
-    });
-    if (bullet === null) return;
-    await prismaClient.bullet.delete({
-      where: {
-        bulletId,
-      },
-    });
+    try {
+      await prismaClient.bullet.delete({
+        where: { bulletId },
+      });
+    } catch (e) {
+      console.error(e);
+    }
   },
 };

--- a/server/repository/enemyRepository.ts
+++ b/server/repository/enemyRepository.ts
@@ -59,17 +59,15 @@ export const enemyRepository = {
     return enemies.length > 0 ? enemies.map(toEnemyModel) : [];
   },
   delete: async (enemyId: EnemyId) => {
-    const enemy = await prismaClient.enemy.findUnique({
-      where: {
-        enemyId,
-      },
-    });
-    if (enemy === null) return;
-    await prismaClient.enemy.delete({
-      where: {
-        enemyId,
-      },
-    });
+    try {
+      await prismaClient.enemy.delete({
+        where: {
+          enemyId,
+        },
+      });
+    } catch (e) {
+      console.error(e);
+    }
   },
   count: async () => {
     const count = prismaClient.enemy.count();

--- a/server/repository/playerRepository.ts
+++ b/server/repository/playerRepository.ts
@@ -8,7 +8,7 @@ import { prismaClient } from '../service/prismaClient';
 const toPlayerModel = (prismaPlayer: Player): PlayerModel => ({
   userId: userIdParser.parse(prismaPlayer.userId),
   name: z.string().parse(prismaPlayer.name),
-  score: z.number().min(0).parse(prismaPlayer.score),
+  score: z.number().parse(prismaPlayer.score),
   pos: z
     .object({
       x: z.number(),

--- a/server/usecase/bulletUsecase.ts
+++ b/server/usecase/bulletUsecase.ts
@@ -46,11 +46,12 @@ export const bulletUseCase = {
     await bulletRepository.save(updateBulletInfo);
     return updateBulletInfo;
   },
-  delete: async (bulletModel: BulletModel): Promise<BulletModel | null> => {
-    const currentBulletInfo = await bulletRepository.find(bulletModel.bulletId);
-    if (currentBulletInfo === null) return null;
-    await bulletRepository.delete(bulletModel.bulletId);
-    return currentBulletInfo;
+  delete: async (bulletModel: BulletModel) => {
+    try {
+      await bulletRepository.delete(bulletModel.bulletId);
+    } catch (e) {
+      console.error(e);
+    }
   },
   update: async () => {
     const currentBulletList = await bulletRepository.findAll();

--- a/server/usecase/bulletUsecase.ts
+++ b/server/usecase/bulletUsecase.ts
@@ -26,7 +26,7 @@ export const bulletUseCase = {
       shooterId,
       power: 1,
       vector: { x: 10, y: 0 },
-      pos: { x: shooterInfo.pos.x - 50, y: shooterInfo.pos.y },
+      pos: { x: shooterInfo.pos.x, y: shooterInfo.pos.y },
       type: 1,
       side: shooterInfo.side,
     };

--- a/server/usecase/collisionUsecase.ts
+++ b/server/usecase/collisionUsecase.ts
@@ -11,7 +11,7 @@ let intervalId: NodeJS.Timeout | null = null;
 
 const divide = async (entities: EntityModel[], displayNumber: number) => {
   const dividedEntitiesByDisplay = [...Array(displayNumber)].map((_, i) => {
-    return entities.filter((entity) => Math.floor(entity.pos.x / 1920) === i);
+    return entities.filter((entity) => Math.abs(Math.floor(entity.pos.x / 1920) - i) < 0.1);
   });
 
   const dividedEntitiesByQuad = dividedEntitiesByDisplay
@@ -95,10 +95,8 @@ const checkCollisions = async () => {
     });
   });
 
-  const setCollisions = collisions.filter((entity, i, self) => self.indexOf(entity) === i);
-
   await Promise.all(
-    setCollisions.map((entity) => {
+    collisions.map((entity) => {
       if ('userId' in entity) {
         return playerUseCase.addScore(entity.userId, -100);
       } else if ('enemyId' in entity) {

--- a/server/usecase/collisionUsecase.ts
+++ b/server/usecase/collisionUsecase.ts
@@ -11,7 +11,7 @@ let intervalId: NodeJS.Timeout | null = null;
 
 const divide = async (entities: EntityModel[], displayNumber: number) => {
   const dividedEntitiesByDisplay = [...Array(displayNumber)].map((_, i) => {
-    return entities.filter((entity) => Math.abs(Math.floor(entity.pos.x / 1920) - i) < 0.1);
+    return entities.filter((entity) => Math.floor(entity.pos.x / 1920) === i);
   });
 
   const dividedEntitiesByQuad = dividedEntitiesByDisplay

--- a/server/usecase/enemyUsecase.ts
+++ b/server/usecase/enemyUsecase.ts
@@ -47,11 +47,12 @@ export const enemyUseCase = {
     await enemyRepository.save(updateEnemyInfo);
     return updateEnemyInfo;
   },
-  delete: async (enemyModel: EnemyModel): Promise<EnemyModel | null> => {
-    const currentEnemyInfo = await enemyRepository.find(enemyModel.enemyId);
-    if (currentEnemyInfo === null) return null;
-    await enemyRepository.delete(enemyModel.enemyId);
-    return currentEnemyInfo;
+  delete: async (enemyModel: EnemyModel) => {
+    try {
+      await enemyRepository.delete(enemyModel.enemyId);
+    } catch (e) {
+      console.error(e);
+    }
   },
   update: async () => {
     const currentEnemyInfos = await enemyRepository.findAll();

--- a/server/usecase/enemyUsecase.ts
+++ b/server/usecase/enemyUsecase.ts
@@ -9,7 +9,7 @@ export const enemyUseCase = {
     intervalId = setInterval(() => {
       enemyUseCase.create();
       enemyUseCase.update();
-    }, 50);
+    }, 100);
   },
   stop: () => {
     if (intervalId) {


### PR DESCRIPTION
## 内容

四分木空間分割に近い処理を導入して当たり判定を実装した。

## 変更点

- 当たり判定
- 敵に当たったときスコアが減るように

## 関連 Issue

Resolve #42 

## スクリーンショット・動画など

https://github.com/INIAD-Developers/Gradius-2023/assets/131662659/19d72524-4ca9-4358-b813-f1f249f3362a


## その他
docker, wsl, vivaldi, OBSを動かしつつ10msのインターバルで当たり判定をやりながら撮影して問題なく動いたので、かなりいい感じな気がします