### PR TITLE
画面ごとにページを分けロビーを追加

### DIFF
--- a/client/src/pages/game/[displayPosition]/index.module.css
+++ b/client/src/pages/game/[displayPosition]/index.module.css
@@ -1,0 +1,10 @@
+.canvasContainer {
+  width: 100vw;
+  height: 100svh;
+  overflow: hidden;
+}
+
+.canvasContainer > div {
+  width: 100vw;
+  height: 100vh;
+}

--- a/client/src/pages/game/[displayPosition]/index.page.tsx
+++ b/client/src/pages/game/[displayPosition]/index.page.tsx
@@ -1,0 +1,141 @@
+import type { BulletModel, EnemyModel, PlayerModel } from 'commonTypesWithClient/models';
+import { useRouter } from 'next/router';
+import { useEffect, useState } from 'react';
+import { Circle, Image, Layer, Stage } from 'react-konva';
+import Boom from 'src/components/Effect/Boom';
+import { staticPath } from 'src/utils/$path';
+import { apiClient } from 'src/utils/apiClient';
+import useImage from 'use-image';
+import styles from './index.module.css';
+
+const Geme = () => {
+  const router = useRouter();
+  const { displayPosition } = router.query;
+
+  const [players, setPlayers] = useState<PlayerModel[]>([]);
+  const [enemies, setEnemies] = useState<EnemyModel[]>([]);
+  const [bullets, setBullets] = useState<BulletModel[]>([]);
+  //TODO: もし、これ以外のエフェクトを追加する場合は、それぞれのエフェクトを区別する型を作成する
+  const [effectPosition, setEffectPosition] = useState<number[][]>([]);
+  const [playerImage] = useImage(staticPath.images.spaceship_png);
+  const [enemyImage1] = useImage(staticPath.images.ufo_jpg);
+
+  const [width, setWidth] = useState<number>(0);
+  const [height, setHeight] = useState<number>(0);
+
+  const fetchPlayers = async () => {
+    const res = await apiClient.player.$get();
+    setPlayers(res);
+  };
+
+  const fetchEnemies = async () => {
+    const res = await apiClient.enemy.$get();
+    const killedEnemies = enemies.filter((enemy) => !res.some((e) => e.enemyId === enemy.enemyId));
+    if (killedEnemies.length > 0) {
+      killedEnemies.forEach((enemy) => {
+        setEffectPosition((prev) => [...prev, [enemy.pos.x - 40, enemy.pos.y - 40]]);
+      });
+    }
+    setEnemies(res);
+  };
+
+  const fetchBullets = async () => {
+    const res = await apiClient.bullet.$get();
+    if (res.length > bullets.length) {
+      const audio = new Audio(staticPath.sounds.shot_mp3);
+      audio.play();
+    }
+    setBullets(res);
+  };
+
+  useEffect(() => {
+    const cancelId = requestAnimationFrame(() => {
+      fetchPlayers();
+      fetchEnemies();
+      fetchBullets();
+    });
+    return () => cancelAnimationFrame(cancelId);
+  });
+
+  useEffect(() => {
+    const timeoutId = setTimeout(() => {
+      setEffectPosition((prev) => prev.slice(1));
+    }, 1000);
+
+    return () => clearTimeout(timeoutId);
+  }, [effectPosition]);
+
+  useEffect(() => {
+    const setWindowSize = () => {
+      setWidth(window.innerWidth);
+      setHeight(window.innerHeight);
+    };
+    setWindowSize();
+    window.addEventListener('resize', setWindowSize);
+    return () => window.removeEventListener('resize', setWindowSize);
+  }, []);
+
+  useEffect(() => {
+    const redirectToLobby = async () => {
+      const res = await apiClient.config.$get();
+      if (Number(displayPosition) >= (res ?? 1)) {
+        router.push('/game');
+      }
+    };
+    redirectToLobby();
+  }, [router, displayPosition]);
+
+  return (
+    <div className={styles.canvasContainer}>
+      <Stage
+        width={1920}
+        height={1080}
+        style={{
+          transform: `
+              scale(${width / 1920}, ${height / 1080})
+              translateX(${(width - 1920) / 2}px)
+              translateY(${(height - 1080) / 2}px)
+              `,
+        }}
+      >
+        <Layer>
+          {bullets.map((bullet) => (
+            <Circle x={bullet.pos.x} y={bullet.pos.y} radius={7} fill="red" key={bullet.bulletId} />
+          ))}
+        </Layer>
+        <Layer>
+          {players.map((player) => (
+            <Image
+              image={playerImage}
+              width={100}
+              height={100}
+              rotation={player.side === 'left' ? 90 : -90}
+              x={player.pos.x + 50}
+              y={player.pos.y - 50}
+              key={player.userId}
+            />
+          ))}
+        </Layer>
+        <Layer>
+          {enemies.map((enemy) => (
+            <Image
+              image={enemyImage1}
+              width={80}
+              height={80}
+              x={enemy.pos.x - 40}
+              y={enemy.pos.y - 40}
+              key={enemy.enemyId}
+            />
+          ))}
+        </Layer>
+        <Layer>
+          {effectPosition.map((position, index) => (
+            <Boom position={position} key={index} />
+          ))}
+        </Layer>
+      </Stage>
+    </div>
+  );
+};
+
+export default Geme;

--- a/client/src/pages/game/index.module.css
+++ b/client/src/pages/game/index.module.css
@@ -1,9 +1,11 @@
 .container {
   display: flex;
-  flex-direction: column;
   align-items: center;
   justify-content: center;
+  width: 100vw;
   height: 100svh;
+  background-image: url('~/public/images/gradius_genesis.png');
+  background-size: cover;
 }
 
 .container > div {
@@ -12,16 +14,41 @@
 
 .text {
   margin-bottom: 1rem;
+  margin-bottom: 4svmin;
+  font-size: 2svmin;
+  font-weight: bold;
+  color: #fff;
   text-align: center;
+  text-shadow: 0 0 0.4svmin #000;
 }
 
 .buttons {
   display: flex;
   flex-wrap: wrap;
+  gap: 1svmin;
   justify-content: center;
 }
 
 .buttons > button {
   width: 8svmin;
   aspect-ratio: 16 / 9;
+  font-size: 2svmin;
+  color: #fff;
+  text-shadow: 0 0 0.4svmin #000;
+  cursor: pointer;
+  background-color: #9997;
+  border: solid 0.3svmin #fff4;
+  border-radius: 1svmin;
+  transition-timing-function: ease-in-out, ease-in;
+  transition-duration: 0.2s, 0.1s;
+  transition-property: background-color, transform;
+  backdrop-filter: blur(0.8svmin);
+}
+
+.buttons > button:hover {
+  background-color: #9994;
+}
+
+.buttons > button:active {
+  transform: scale(0.9);
 }

--- a/client/src/pages/game/index.module.css
+++ b/client/src/pages/game/index.module.css
@@ -1,10 +1,27 @@
-.canvasContainer {
-  width: 100vw;
+.container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
   height: 100svh;
-  overflow: hidden;
 }
 
-.canvasContainer > div {
-  width: 100vw;
-  height: 100vh;
+.container > div {
+  width: 88svmin;
+}
+
+.text {
+  margin-bottom: 1rem;
+  text-align: center;
+}
+
+.buttons {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+
+.buttons > button {
+  width: 8svmin;
+  aspect-ratio: 16 / 9;
 }

--- a/client/src/pages/game/index.page.tsx
+++ b/client/src/pages/game/index.page.tsx
@@ -1,125 +1,37 @@
-import type { BulletModel, EnemyModel, PlayerModel } from 'commonTypesWithClient/models';
-import { useEffect, useState } from 'react';
-import { Circle, Image, Layer, Stage } from 'react-konva';
-import Boom from 'src/components/Effect/Boom';
-import { staticPath } from 'src/utils/$path';
+import { useRouter } from 'next/router';
+import { useCallback, useEffect, useState } from 'react';
 import { apiClient } from 'src/utils/apiClient';
-import useImage from 'use-image';
 import styles from './index.module.css';
 
 const Game = () => {
-  const [players, setPlayers] = useState<PlayerModel[]>([]);
-  const [enemies, setEnemies] = useState<EnemyModel[]>([]);
-  const [bullets, setBullets] = useState<BulletModel[]>([]);
-  //TODO: もし、これ以外のエフェクトを追加する場合は、それぞれのエフェクトを区別する型を作成する
-  const [effectPosition, setEffectPosition] = useState<number[][]>([]);
-  const [playerImage] = useImage(staticPath.images.spaceship_png);
-  const [enemyImage1] = useImage(staticPath.images.ufo_jpg);
+  const [displayNumber, setDisplayNumber] = useState<number>(0);
+  const router = useRouter();
 
-  const [width, setWidth] = useState<number>(0);
-  const [height, setHeight] = useState<number>(0);
+  const fetchDisplayNumber = useCallback(async () => {
+    const res = await apiClient.config.$get();
+    setDisplayNumber(res ?? 0);
 
-  const fetchPlayers = async () => {
-    const res = await apiClient.player.$get();
-    setPlayers(res);
-  };
-
-  const fetchEnemies = async () => {
-    const res = await apiClient.enemy.$get();
-    const killedEnemies = enemies.filter((enemy) => !res.some((e) => e.enemyId === enemy.enemyId));
-    if (killedEnemies.length > 0) {
-      killedEnemies.forEach((enemy) => {
-        setEffectPosition((prev) => [...prev, [enemy.pos.x - 40, enemy.pos.y - 40]]);
-      });
+    if (res === 0) {
+      router.push('/config');
     }
-    setEnemies(res);
-  };
-
-  const fetchBullets = async () => {
-    const res = await apiClient.bullet.$get();
-    if (res.length > bullets.length) {
-      const audio = new Audio(staticPath.sounds.shot_mp3);
-      audio.play();
-    }
-    setBullets(res);
-  };
+  }, [router]);
 
   useEffect(() => {
-    const cancelId = requestAnimationFrame(() => {
-      fetchPlayers();
-      fetchEnemies();
-      fetchBullets();
-    });
-    return () => cancelAnimationFrame(cancelId);
-  });
-
-  useEffect(() => {
-    const timeoutId = setTimeout(() => {
-      setEffectPosition((prev) => prev.slice(1));
-    }, 1000);
-
-    return () => clearTimeout(timeoutId);
-  }, [effectPosition]);
-
-  useEffect(() => {
-    const setWindowSize = () => {
-      setWidth(window.innerWidth);
-      setHeight(window.innerHeight);
-    };
-    setWindowSize();
-    window.addEventListener('resize', setWindowSize);
-    return () => window.removeEventListener('resize', setWindowSize);
-  }, []);
+    fetchDisplayNumber();
+  }, [fetchDisplayNumber]);
 
   return (
-    <div className={styles.canvasContainer}>
-      <Stage
-        width={1920}
-        height={1080}
-        style={{
-          transform: `
-              scale(${width / 1920}, ${height / 1080})
-              translateX(${(width - 1920) / 2}px)
-              translateY(${(height - 1080) / 2}px)
-              `,
-        }}
-      >
-        <Layer>
-          {bullets.map((bullet) => (
-            <Circle x={bullet.pos.x} y={bullet.pos.y} radius={7} fill="red" key={bullet.bulletId} />
+    <div className={styles.container}>
+      <div>
+        <p className={styles.text}>ディスプレイの位置を選択してください</p>
+        <div className={styles.buttons}>
+          {[...Array(displayNumber)].map((_, i) => (
+            <button key={i} onClick={() => router.push(`/game/${i}`)}>
+              {i + 1}
+            </button>
           ))}
-        </Layer>
-        <Layer>
-          {players.map((player) => (
-            <Image
-              image={playerImage}
-              width={100}
-              height={100}
-              rotation={player.side === 'left' ? 90 : -90}
-              x={player.pos.x + 50}
-              y={player.pos.y - 50}
-              key={player.userId}
-            />
-          ))}
-        </Layer>
-        <Layer>
-          {enemies.map((enemy) => (
-            <Image
-              image={enemyImage1}
-              width={80}
-              height={80}
-              x={enemy.pos.x - 40}
-              y={enemy.pos.y - 40}
-              key={enemy.enemyId}
-            />
-          ))}
-        </Layer>
-        <Layer>
-          {effectPosition.map((position, index) => (
-            <Boom position={position} key={index} />
-          ))}
-        </Layer>
-      </Stage>
+        </div>
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
## 内容

何番目の画面かによってページを分け、それらへのリンクを置くロビーを追加

## 変更点

- 既存のゲームページを`/game/[displayPosition]`に移動
- `/game`にロビーを追加

## 関連 Issue



## スクリーンショット・動画など

![image](https://github.com/INIAD-Developers/Gradius-2023/assets/131662659/725f4f6b-e21e-4a8f-af25-7b278a0dfecf)

## その他
今はどのページも同じ内容が表示されます。