### PR TITLE
displayごとにplayerを表示

### DIFF
--- a/client/src/pages/game/[displayPosition]/index.page.tsx
+++ b/client/src/pages/game/[displayPosition]/index.page.tsx
@@ -35,7 +35,6 @@ const Game = () => {
     });
     setPlayers(res);
   };
-  console.log(players);
 
   const fetchEnemies = async () => {
     const res = await apiClient.enemy.$get();

--- a/client/src/pages/game/[displayPosition]/index.page.tsx
+++ b/client/src/pages/game/[displayPosition]/index.page.tsx
@@ -8,9 +8,15 @@ import { apiClient } from 'src/utils/apiClient';
 import useImage from 'use-image';
 import styles from './index.module.css';
 
-const Geme = () => {
+const Game = () => {
   const router = useRouter();
-  const { displayPosition } = router.query;
+  let displayPosition: number | null = null;
+  if (typeof router.query.displayPosition === 'string') {
+    const parsed = Number(router.query.displayPosition);
+    if (!isNaN(parsed)) {
+      displayPosition = parsed;
+    }
+  }
 
   const [players, setPlayers] = useState<PlayerModel[]>([]);
   const [enemies, setEnemies] = useState<EnemyModel[]>([]);
@@ -24,9 +30,12 @@ const Geme = () => {
   const [height, setHeight] = useState<number>(0);
 
   const fetchPlayers = async () => {
-    const res = await apiClient.player.$get({ query: {} });
+    const res = await apiClient.player.$get({
+      query: { displayNumber: Number(displayPosition) },
+    });
     setPlayers(res);
   };
+  console.log(players);
 
   const fetchEnemies = async () => {
     const res = await apiClient.enemy.$get();
@@ -104,17 +113,20 @@ const Geme = () => {
           ))}
         </Layer>
         <Layer>
-          {players.map((player) => (
-            <Image
-              image={playerImage}
-              width={100}
-              height={100}
-              rotation={player.side === 'left' ? 90 : -90}
-              x={player.pos.x + 50}
-              y={player.pos.y - 50}
-              key={player.userId}
-            />
-          ))}
+          {players.map(
+            (player) =>
+              displayPosition !== null && (
+                <Image
+                  image={playerImage}
+                  width={100}
+                  height={100}
+                  rotation={player.side === 'left' ? 90 : -90}
+                  x={player.pos.x - 1920 * displayPosition + 50}
+                  y={player.pos.y - 50}
+                  key={player.userId}
+                />
+              )
+          )}
         </Layer>
         <Layer>
           {enemies.map((enemy) => (
@@ -138,4 +150,4 @@ const Geme = () => {
   );
 };
 
-export default Geme;
+export default Game;

--- a/client/src/pages/login/index.page.tsx
+++ b/client/src/pages/login/index.page.tsx
@@ -32,7 +32,8 @@ const Login = () => {
   };
 
   const fetchPlayers = async () => {
-    const res = await apiClient.player.$get({ query: {} });
+    //一時的にdisplayNumber:0で固定
+    const res = await apiClient.player.$get({ query: { displayNumber: 0 } });
     setPlayersPlaying(res.filter((player) => player.isPlaying));
     setPlayersDead(res.filter((player) => !player.isPlaying));
   };

--- a/server/api/player/controller.ts
+++ b/server/api/player/controller.ts
@@ -1,9 +1,11 @@
-import { playerRepository } from '$/repository/playerRepository';
 import { playerUseCase } from '$/usecase/playerUsecase';
 import { defineController } from './$relay';
 
 export default defineController(() => ({
-  get: async () => ({ status: 200, body: (await playerRepository.findAll()) ?? [] }),
+  get: async ({ query }) => ({
+    status: 200,
+    body: (await playerUseCase.getPlayersByDisplayNumber(query.displayNumber)) ?? [],
+  }),
   post: async ({ body }) => ({
     status: 200,
     body: await playerUseCase.create(body.name, body.teamInfo),

--- a/server/api/player/index.ts
+++ b/server/api/player/index.ts
@@ -4,7 +4,7 @@ import type { PlayerModel } from '../../commonTypesWithClient/models';
 export type Methods = DefineMethods<{
   get: {
     query: {
-      isPlaying?: boolean;
+      displayNumber: number;
     };
     resBody: PlayerModel[];
   };

--- a/server/usecase/playerUsecase.ts
+++ b/server/usecase/playerUsecase.ts
@@ -87,4 +87,14 @@ export const playerUseCase = {
 
     return updatePlayerInfo;
   },
+  getPlayersByDisplayNumber: async (displayNumber: number) => {
+    const players = await playerRepository.findAll();
+    const playersByDisplayNumber = players.filter((player) => {
+      if (typeof player.pos.x === 'number' && player.isPlaying) {
+        return Math.floor(player.pos.x / 1920) === displayNumber;
+      }
+      return [];
+    });
+    return playersByDisplayNumber;
+  },
 };


### PR DESCRIPTION
## 内容

表示されているdisplayごとにそこにいるplayerを表示

## 変更点

１，playerUsecaseに渡されたdisplayNumberにいるplayerを返すgetPlayersByDisplayNumberを追加
２，api/playerのgetを１を呼ぶように
３，[displayPosition]のゲーム画面で表示

## その他
api/playerのgetをlogin画面でも使っていたためそこでは一時的にdisplayNumberを0に固定していますが、別のapiを作るか何かして変更する必要があります