### PR TITLE
バックエンドの処理を改善

### DIFF
--- a/client/src/components/Entity/Bullet.tsx
+++ b/client/src/components/Entity/Bullet.tsx
@@ -3,6 +3,7 @@ import type { BulletModel } from 'commonTypesWithClient/models';
 import { useMemo } from 'react';
 import { Image } from 'react-konva';
 import { staticPath } from 'src/utils/$path';
+import { computePosition } from 'src/utils/computePosition';
 import useImage from 'use-image';
 
 type Props = {
@@ -16,16 +17,18 @@ export const Bullet = ({ displayPosition, bullet }: Props) => {
 
   const images = [bulletImage1, bulletImage2];
 
+  const pos = computePosition(bullet.createdPos, bullet.createdAt, bullet.direction);
+
   const ownerType = useMemo(() => {
     return bullet.side === 'left' ? 0 : 1;
   }, [bullet.side]);
 
   const relativePos = useMemo(() => {
     return {
-      x: bullet.pos.x - BULLET_RADIUS - displayPosition * SCREEN_WIDTH,
-      y: bullet.pos.y - BULLET_RADIUS,
+      x: pos.x - BULLET_RADIUS - displayPosition * SCREEN_WIDTH,
+      y: pos.y - BULLET_RADIUS,
     };
-  }, [bullet.pos, displayPosition]);
+  }, [pos, displayPosition]);
 
   return (
     <Image

--- a/client/src/components/Entity/Enemy.tsx
+++ b/client/src/components/Entity/Enemy.tsx
@@ -3,6 +3,7 @@ import type { EnemyModel } from 'commonTypesWithClient/models';
 import { useMemo } from 'react';
 import { Image } from 'react-konva';
 import { staticPath } from 'src/utils/$path';
+import { computePosition } from 'src/utils/computePosition';
 import useImage from 'use-image';
 
 type Props = {
@@ -17,12 +18,14 @@ export const Enemy = ({ displayPosition, enemy }: Props) => {
 
   const images = [enemyImage1, enemyImage2, enemyImage3];
 
+  const pos = computePosition(enemy.createdPos, enemy.createdAt, enemy.direction);
+
   const relativePos = useMemo(() => {
     return {
-      x: enemy.pos.x - ENEMY_HALF_WIDTH - displayPosition * SCREEN_WIDTH,
-      y: enemy.pos.y - ENEMY_HALF_WIDTH,
+      x: pos.x - ENEMY_HALF_WIDTH - displayPosition * SCREEN_WIDTH,
+      y: pos.y - ENEMY_HALF_WIDTH,
     };
-  }, [displayPosition, enemy.pos]);
+  }, [displayPosition, pos]);
 
   return (
     <Image

--- a/client/src/pages/controller/index.page.tsx
+++ b/client/src/pages/controller/index.page.tsx
@@ -31,7 +31,7 @@ const Home = () => {
   const router = useRouter();
 
   const MOVE_INTERVAL_TIME = 20;
-  const SHOOT_INTERVAL_TIME = 800;
+  const SHOOT_INTERVAL_TIME = 50;
 
   const getUserId = useCallback(async () => {
     const localStorageUserId = getUserIdFromLocalStorage();

--- a/client/src/pages/game/[displayPosition]/index.page.tsx
+++ b/client/src/pages/game/[displayPosition]/index.page.tsx
@@ -49,7 +49,7 @@ const Game = () => {
   const fetchEnemies = async () => {
     const res = await apiClient.enemy.$get();
     const display = Number(displayPosition);
-    const killedEnemies = enemies.filter((enemy) => !res.some((e) => e.enemyId === enemy.enemyId));
+    const killedEnemies = enemies.filter((enemy) => !res.some((e) => e.id === enemy.id));
     if (killedEnemies.length > 0) {
       killedEnemies.forEach((enemy) => {
         setEffectPosition((prev) => [
@@ -134,17 +134,17 @@ const Game = () => {
         </Layer>
         <Layer>
           {bullets.map((bullet) => (
-            <Bullet displayPosition={displayPosition ?? 0} bullet={bullet} key={bullet.bulletId} />
+            <Bullet displayPosition={displayPosition ?? 0} bullet={bullet} key={bullet.id} />
           ))}
         </Layer>
         <Layer>
           {players.map((player) => (
-            <Player displayPosition={displayPosition ?? 0} player={player} key={player.userId} />
+            <Player displayPosition={displayPosition ?? 0} player={player} key={player.id} />
           ))}
         </Layer>
         <Layer>
           {enemies.map((enemy) => (
-            <Enemy displayPosition={displayPosition ?? 0} enemy={enemy} key={enemy.enemyId} />
+            <Enemy displayPosition={displayPosition ?? 0} enemy={enemy} key={enemy.id} />
           ))}
         </Layer>
         <Layer>

--- a/client/src/pages/game/[displayPosition]/index.page.tsx
+++ b/client/src/pages/game/[displayPosition]/index.page.tsx
@@ -9,6 +9,7 @@ import { Enemy } from 'src/components/Entity/Enemy';
 import { Player } from 'src/components/Entity/Player';
 import { staticPath } from 'src/utils/$path';
 import { apiClient } from 'src/utils/apiClient';
+import { computePosition } from 'src/utils/computePosition';
 import useImage from 'use-image';
 import styles from './index.module.css';
 
@@ -48,13 +49,13 @@ const Game = () => {
 
   const fetchEnemies = async () => {
     const res = await apiClient.enemy.$get();
-    const display = Number(displayPosition);
     const killedEnemies = enemies.filter((enemy) => !res.some((e) => e.id === enemy.id));
     if (killedEnemies.length > 0) {
       killedEnemies.forEach((enemy) => {
+        const pos = computePosition(enemy.createdPos, enemy.createdAt, enemy.direction);
         setEffectPosition((prev) => [
           ...prev,
-          [enemy.pos.x - ENEMY_HALF_WIDTH, enemy.pos.y - ENEMY_HALF_WIDTH],
+          [pos.x - ENEMY_HALF_WIDTH, pos.y - ENEMY_HALF_WIDTH],
         ]);
       });
     }

--- a/client/src/pages/login/index.page.tsx
+++ b/client/src/pages/login/index.page.tsx
@@ -10,7 +10,6 @@ const Login = () => {
   const [name, setName] = useState<string>('');
   const [playersPlaying, setPlayersPlaying] = useState<PlayerModel[]>([]);
   const [playersDead, setPlayersDead] = useState<PlayerModel[]>([]);
-  // const [team, setTeam] = useState(1);
 
   const router = useRouter();
 
@@ -25,22 +24,10 @@ const Login = () => {
     setName(e.target.value);
   };
 
-  // const changTeam = (type: string) => {
-  //   if (type === 'red') setTeam(1);
-  //   if (type === 'blue') setTeam(2);
-  // };
-
   const login = async () => {
-    const playersInfo: PlayerModel[] = await apiClient.player.info.$get();
-    let team = 1;
-    const left = playersInfo.filter((player) => player.side === 'left');
-    const right = playersInfo.filter((player) => player.side === 'right');
-
-    if (left > right) team = 2;
-    const player: PlayerModel = await apiClient.player.$post({ body: { name, teamInfo: team } });
-    loginWithLocalStorage(player.userId);
+    const player: PlayerModel = await apiClient.player.$post({ body: { name } });
+    loginWithLocalStorage(player.id);
     router.push('/controller');
-    team = 1;
   };
 
   const fetchPlayers = async () => {
@@ -77,7 +64,7 @@ const Login = () => {
         <p>{playerCount}人</p>
         <div className={styles.players}>
           {playersPlaying.slice(0, 10).map((player) => (
-            <div key={player.userId}>{player.name}</div>
+            <div key={player.id}>{player.name}</div>
           ))}
         </div>
       </div>
@@ -98,7 +85,7 @@ const Login = () => {
         <h2>ランキング</h2>
         <div className={styles.ranking}>
           {playerRanking.map((player, i) => (
-            <div key={player.userId}>
+            <div key={player.id}>
               <div>
                 {i + 1}位 ({player.score}点)
               </div>

--- a/client/src/utils/computePosition.ts
+++ b/client/src/utils/computePosition.ts
@@ -1,0 +1,15 @@
+type Pos = {
+  x: number;
+  y: number;
+};
+
+export const computePosition = (createdPos: Pos, createdAt: number, direction: Pos) => {
+  const now = Date.now();
+  const timeDiff = now - createdAt;
+  const distance = (timeDiff / 1000) * 300;
+
+  return {
+    x: createdPos.x + direction.x * distance,
+    y: createdPos.y + direction.y * distance,
+  };
+};

--- a/server/api/bullet/controller.ts
+++ b/server/api/bullet/controller.ts
@@ -4,7 +4,7 @@ import { defineController } from './$relay';
 export default defineController(() => ({
   get: async ({ query }) => ({
     status: 200,
-    body: (await bulletUseCase.getBulletByDisplayNumber(query.displayNumber)) ?? [],
+    body: (await bulletUseCase.getBulletInDisplay(query.displayNumber)) ?? [],
   }),
   post: async ({ body }) => ({ status: 200, body: await bulletUseCase.create(body.userId) }),
 }));

--- a/server/api/enemy/controller.ts
+++ b/server/api/enemy/controller.ts
@@ -1,7 +1,8 @@
+import { enemyRepository } from '$/repository/enemyRepository';
 import { enemyUseCase } from '$/usecase/enemyUsecase';
 import { defineController } from './$relay';
 
 export default defineController(() => ({
-  get: async () => ({ status: 200, body: await enemyUseCase.findAll() }),
+  get: async () => ({ status: 200, body: await enemyRepository.findAll() }),
   post: async () => ({ status: 200, body: await enemyUseCase.create() }),
 }));

--- a/server/api/player/control/controller.ts
+++ b/server/api/player/control/controller.ts
@@ -1,10 +1,11 @@
+import { playerRepository } from '$/repository/playerRepository';
 import { playerUseCase } from '$/usecase/playerUsecase';
 import { defineController } from './$relay';
 
 export default defineController(() => ({
   get: async ({ query }) => ({
     status: 200,
-    body: await playerUseCase.getStatus(query.userId),
+    body: await playerRepository.find(query.userId),
   }),
   post: async ({ body }) => ({
     status: 200,

--- a/server/api/player/controller.ts
+++ b/server/api/player/controller.ts
@@ -4,10 +4,10 @@ import { defineController } from './$relay';
 export default defineController(() => ({
   get: async ({ query }) => ({
     status: 200,
-    body: (await playerUseCase.getPlayersByDisplayNumber(query.displayNumber)) ?? [],
+    body: (await playerUseCase.getPlayersInDisplay(query.displayNumber)) ?? [],
   }),
   post: async ({ body }) => ({
     status: 200,
-    body: await playerUseCase.create(body.name, body.teamInfo),
+    body: await playerUseCase.create(body.name),
   }),
 }));

--- a/server/api/player/index.ts
+++ b/server/api/player/index.ts
@@ -11,7 +11,6 @@ export type Methods = DefineMethods<{
   post: {
     reqBody: {
       name: string;
-      teamInfo: number;
     };
     resBody: PlayerModel;
   };

--- a/server/api/player/info/controller.ts
+++ b/server/api/player/info/controller.ts
@@ -1,6 +1,6 @@
-import { playerUseCase } from '$/usecase/playerUsecase';
+import { playerRepository } from '$/repository/playerRepository';
 import { defineController } from './$relay';
 
 export default defineController(() => ({
-  get: async () => ({ status: 200, body: await playerUseCase.getAllStatus() }),
+  get: async () => ({ status: 200, body: await playerRepository.findAll() }),
 }));

--- a/server/commonTypesWithClient/models.ts
+++ b/server/commonTypesWithClient/models.ts
@@ -20,17 +20,13 @@ export type GameModel = {
 };
 
 export type PlayerModel = {
-  userId: UserId;
+  id: UserId;
   name: string;
   pos: {
     x: number;
     y: number;
   };
   score: number;
-  vector: {
-    x: number;
-    y: number;
-  };
   Items:
     | {
         id: string;
@@ -42,31 +38,30 @@ export type PlayerModel = {
 };
 
 export type EnemyModel = {
-  enemyId: EnemyId;
-  score: number;
-  pos: {
+  id: EnemyId;
+  direction: {
     x: number;
     y: number;
   };
-  vector: {
+  createdPos: {
     x: number;
     y: number;
   };
+  createdAt: number;
   type: number;
 };
 
 export type BulletModel = {
-  bulletId: BulletId;
-  power: number;
-  pos: {
+  id: BulletId;
+  direction: {
     x: number;
     y: number;
   };
-  vector: {
+  createdPos: {
     x: number;
     y: number;
   };
-  type: number;
+  createdAt: number;
   side: 'left' | 'right';
   shooterId: string;
 };

--- a/server/prisma/migrations/20230907103838_/migration.sql
+++ b/server/prisma/migrations/20230907103838_/migration.sql
@@ -1,0 +1,44 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `power` on the `Bullet` table. All the data in the column will be lost.
+  - You are about to drop the column `type` on the `Bullet` table. All the data in the column will be lost.
+  - You are about to drop the column `vector` on the `Bullet` table. All the data in the column will be lost.
+  - You are about to drop the column `pos` on the `Enemy` table. All the data in the column will be lost.
+  - You are about to drop the column `score` on the `Enemy` table. All the data in the column will be lost.
+  - You are about to drop the column `vector` on the `Enemy` table. All the data in the column will be lost.
+  - You are about to drop the column `pos` on the `Player` table. All the data in the column will be lost.
+  - You are about to drop the column `vector` on the `Player` table. All the data in the column will be lost.
+  - Added the required column `createdAt` to the `Bullet` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `createdPos` to the `Bullet` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `direction` to the `Bullet` table without a default value. This is not possible if the table is not empty.
+  - Made the column `shooterId` on table `Bullet` required. This step will fail if there are existing NULL values in that column.
+  - Added the required column `createdAt` to the `Enemy` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `createdPos` to the `Enemy` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `direction` to the `Enemy` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `x` to the `Player` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `y` to the `Player` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "Bullet" DROP COLUMN "power",
+DROP COLUMN "type",
+DROP COLUMN "vector",
+ADD COLUMN     "createdAt" TIMESTAMP(3) NOT NULL,
+ADD COLUMN     "createdPos" JSONB NOT NULL,
+ADD COLUMN     "direction" JSONB NOT NULL,
+ALTER COLUMN "shooterId" SET NOT NULL;
+
+-- AlterTable
+ALTER TABLE "Enemy" DROP COLUMN "pos",
+DROP COLUMN "score",
+DROP COLUMN "vector",
+ADD COLUMN     "createdAt" TIMESTAMP(3) NOT NULL,
+ADD COLUMN     "createdPos" JSONB NOT NULL,
+ADD COLUMN     "direction" JSONB NOT NULL;
+
+-- AlterTable
+ALTER TABLE "Player" DROP COLUMN "pos",
+DROP COLUMN "vector",
+ADD COLUMN     "x" INTEGER NOT NULL,
+ADD COLUMN     "y" INTEGER NOT NULL;

--- a/server/prisma/migrations/20230907104551_/migration.sql
+++ b/server/prisma/migrations/20230907104551_/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `pos` on the `Bullet` table. All the data in the column will be lost.
+
+*/
+-- AlterTable
+ALTER TABLE "Bullet" DROP COLUMN "pos";

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -22,28 +22,28 @@ model Game {
 model Player {
   userId    String  @id
   name      String
-  pos       Json
+  x         Int
+  y         Int
   score     Int
-  vector    Json
   Item      Json?
   side      String
   isPlaying Boolean
 }
 
 model Enemy {
-  enemyId String @id
-  pos     Json
-  score   Int
-  vector  Json
-  type    Int
+  enemyId    String   @id
+  direction  Json
+  createdAt  DateTime
+  createdPos Json
+  type       Int
 }
 
 model Bullet {
-  bulletId  String  @id
-  pos       Json
-  power     Int
-  vector    Json
-  type      Int
-  side      String
-  shooterId String?
+  bulletId   String   @id
+  pos        Json
+  direction  Json
+  createdAt  DateTime
+  createdPos Json
+  side       String
+  shooterId  String
 }

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -40,7 +40,6 @@ model Enemy {
 
 model Bullet {
   bulletId   String   @id
-  pos        Json
   direction  Json
   createdAt  DateTime
   createdPos Json

--- a/server/repository/enemyRepository.ts
+++ b/server/repository/enemyRepository.ts
@@ -6,69 +6,59 @@ import { z } from 'zod';
 import type { EnemyId } from '../commonTypesWithClient/branded';
 
 const toEnemyModel = (prismaEnemy: Enemy): EnemyModel => ({
-  enemyId: enemyIdParser.parse(prismaEnemy.enemyId),
-  score: z.number().min(0).parse(prismaEnemy.score),
-  vector: z
+  id: enemyIdParser.parse(prismaEnemy.enemyId),
+  direction: z
     .object({
       x: z.number(),
       y: z.number(),
     })
-    .parse(prismaEnemy.vector),
-  pos: z
+    .parse(prismaEnemy.direction),
+  createdPos: z
     .object({
       x: z.number(),
       y: z.number(),
     })
-    .parse(prismaEnemy.pos),
+    .parse(prismaEnemy.createdPos),
+  createdAt: prismaEnemy.createdAt.getTime(),
   type: z.number().min(0).parse(prismaEnemy.type),
 });
 
 export const enemyRepository = {
-  save: async (enemy: EnemyModel): Promise<EnemyModel> => {
-    const prismaEnemy = await prismaClient.enemy.upsert({
-      where: {
-        enemyId: enemy.enemyId,
-      },
-      update: {
-        score: enemy.score,
-        pos: enemy.pos,
-      },
-      create: {
-        enemyId: enemy.enemyId,
-        score: enemy.score,
-        pos: enemy.pos,
-        vector: enemy.vector,
+  create: async (enemy: EnemyModel): Promise<EnemyModel> => {
+    const prismaEnemy = await prismaClient.enemy.create({
+      data: {
+        enemyId: enemy.id,
+        direction: enemy.direction,
+        createdPos: enemy.createdPos,
+        createdAt: new Date(enemy.createdAt),
         type: enemy.type,
       },
     });
+
     return toEnemyModel(prismaEnemy);
   },
+
   find: async (enemyId: EnemyId): Promise<EnemyModel | null> => {
     const enemy = await prismaClient.enemy.findUnique({
+      where: { enemyId },
+    });
+
+    return enemy !== null ? toEnemyModel(enemy) : null;
+  },
+
+  findAll: async (): Promise<EnemyModel[]> => {
+    const enemies = await prismaClient.enemy.findMany();
+    return enemies.map(toEnemyModel);
+  },
+
+  delete: async (enemyId: EnemyId) => {
+    await prismaClient.enemy.deleteMany({
       where: {
         enemyId,
       },
     });
-    if (enemy === null) {
-      return null;
-    }
-    return toEnemyModel(enemy);
   },
-  findAll: async (): Promise<EnemyModel[]> => {
-    const enemies = await prismaClient.enemy.findMany();
-    return enemies.length > 0 ? enemies.map(toEnemyModel) : [];
-  },
-  delete: async (enemyId: EnemyId) => {
-    try {
-      await prismaClient.enemy.delete({
-        where: {
-          enemyId,
-        },
-      });
-    } catch (e) {
-      console.error(e);
-    }
-  },
+
   count: async () => {
     const count = prismaClient.enemy.count();
     return count;

--- a/server/service/computePositions.ts
+++ b/server/service/computePositions.ts
@@ -1,0 +1,14 @@
+import type { BulletModel, EnemyModel, PlayerModel } from '$/commonTypesWithClient/models';
+
+export const computePosition = (entity: PlayerModel | EnemyModel | BulletModel) => {
+  if ('pos' in entity) return entity.pos;
+
+  const now = Date.now();
+  const timeDiff = now - entity.createdAt;
+  const distance = (timeDiff / 1000) * 300;
+
+  return {
+    x: entity.createdPos.x + entity.direction.x * distance,
+    y: entity.createdPos.y + entity.direction.y * distance,
+  };
+};

--- a/server/usecase/bulletUsecase.ts
+++ b/server/usecase/bulletUsecase.ts
@@ -8,57 +8,48 @@ import { randomUUID } from 'crypto';
 import type { BulletModel } from '../commonTypesWithClient/models';
 
 let intervalId: NodeJS.Timeout | null = null;
+const BULLET_UPDATE_INTERVAL = 25;
 
 export const bulletUseCase = {
   init: () => {
     intervalId = setInterval(() => {
       bulletUseCase.update();
-    }, 25);
+    }, BULLET_UPDATE_INTERVAL);
   },
+
   stop: () => {
-    if (intervalId) {
+    if (intervalId !== null) {
       clearInterval(intervalId);
       intervalId = null;
     }
   },
+
   create: async (shooterId: UserId): Promise<BulletModel | null> => {
     const shooterInfo = await playerRepository.find(shooterId);
     if (shooterInfo === null) return null;
+
     const newBullet: BulletModel = {
-      bulletId: bulletIdParser.parse(randomUUID()),
-      shooterId,
-      power: 1,
-      vector: { x: 10 * (shooterInfo.side === 'left' ? 1 : -1), y: 0 },
-      pos: {
+      id: bulletIdParser.parse(randomUUID()),
+      direction: {
+        x: 10 * (shooterInfo.side === 'left' ? 1 : -1),
+        y: 0,
+      },
+      createdPos: {
         x: shooterInfo.pos.x + PLAYER_HALF_WIDTH * (shooterInfo.side === 'left' ? 1 : -1),
         y: shooterInfo.pos.y,
       },
-      type: 1,
+      createdAt: Date.now(),
       side: shooterInfo.side,
+      shooterId,
     };
-    await bulletRepository.save(newBullet);
-    return newBullet;
+
+    return await bulletRepository.create(newBullet);
   },
-  move: async (bulletModel: BulletModel): Promise<BulletModel | null> => {
-    const currentBulletInfo = await bulletRepository.find(bulletModel.bulletId);
-    if (currentBulletInfo === null) return null;
-    const updateBulletInfo: BulletModel = {
-      ...currentBulletInfo,
-      pos: {
-        x: currentBulletInfo.pos.x + currentBulletInfo.vector.x,
-        y: currentBulletInfo.pos.y + currentBulletInfo.vector.y,
-      },
-    };
-    await bulletRepository.save(updateBulletInfo);
-    return updateBulletInfo;
-  },
+
   delete: async (bulletModel: BulletModel) => {
-    try {
-      await bulletRepository.delete(bulletModel.bulletId);
-    } catch (e) {
-      console.error(e);
-    }
+    await bulletRepository.delete(bulletModel.id);
   },
+
   update: async () => {
     const currentBulletList = await bulletRepository.findAll();
     const displayNumber = (await gameRepository.find().then((game) => game?.displayNumber)) ?? 1;
@@ -74,24 +65,19 @@ export const bulletUseCase = {
       return terms.some(Boolean);
     };
 
-    await Promise.all(
-      currentBulletList.map((bullet) => {
-        if (outOfDisplay(bullet.pos)) {
-          return bulletUseCase.delete(bullet);
-        } else {
-          return bulletUseCase.move(bullet);
-        }
-      })
-    );
+    // await Promise.all(
+    //   currentBulletList.filter((bullet) => outOfDisplay(bullet.pos)).map(bulletUseCase.delete)
+    // );
   },
-  getBulletByDisplayNumber: async (displayNumber: number) => {
+
+  getBulletInDisplay: async (displayNumber: number) => {
     const bullets = await bulletRepository.findAll();
-    const bulletsByDisplayNumber = bullets.filter((bullet) => {
-      if (typeof bullet.pos.x === 'number') {
-        return Math.floor(bullet.pos.x / SCREEN_WIDTH) === displayNumber;
-      }
-      return [];
-    });
-    return bulletsByDisplayNumber;
+    // const bulletsByDisplayNumber = bullets.filter((bullet) => {
+    //   if (typeof bullet.pos.x === 'number') {
+    //     return Math.floor(bullet.pos.x / SCREEN_WIDTH) === displayNumber;
+    //   }
+    //   return [];
+    // });
+    // return bulletsByDisplayNumber;
   },
 };

--- a/server/usecase/collisionUsecase.ts
+++ b/server/usecase/collisionUsecase.ts
@@ -100,23 +100,6 @@ const isOtherSide = (target1: EntityModel, target2: EntityModel) => {
   );
 };
 
-const isAnotherEntity = (target1: EntityModel, target2: EntityModel) => {
-  const id1 =
-    'userId' in target1
-      ? target1.userId
-      : 'enemyId' in target1
-      ? target1.enemyId
-      : target1.bulletId;
-  const id2 =
-    'userId' in target2
-      ? target2.userId
-      : 'enemyId' in target2
-      ? target2.enemyId
-      : target2.bulletId;
-
-  return id1 !== id2;
-};
-
 const checkCollisions = async () => {
   const entities = await Promise.all([
     playerRepository.findAll(),
@@ -133,7 +116,7 @@ const checkCollisions = async () => {
       return entities
         .filter((entity2) => {
           const terms = [
-            isAnotherEntity(entity1, entity2),
+            entity1.id !== entity2.id,
             isOtherSide(entity1, entity2),
             isCollision(entity1, entity2),
           ];
@@ -145,12 +128,12 @@ const checkCollisions = async () => {
 
   await Promise.all(
     collisions.map((entity) => {
-      if ('userId' in entity) {
-        return playerUseCase.addScore(entity.userId, -100);
-      } else if ('enemyId' in entity) {
-        return enemyRepository.delete(entity.enemyId);
+      if ('score' in entity) {
+        return playerUseCase.addScore(entity.id, -100);
+      } else if ('side' in entity) {
+        return bulletRepository.delete(entity.id);
       } else {
-        return bulletRepository.delete(entity.bulletId);
+        return enemyRepository.delete(entity.id);
       }
     })
   );

--- a/server/usecase/enemyUsecase.ts
+++ b/server/usecase/enemyUsecase.ts
@@ -2,6 +2,7 @@ import { SCREEN_HEIGHT, SCREEN_WIDTH } from '$/commonConstantsWithClient';
 import type { EnemyModel } from '$/commonTypesWithClient/models';
 import { enemyRepository } from '$/repository/enemyRepository';
 import { gameRepository } from '$/repository/gameRepository';
+import { computePosition } from '$/service/computePositions';
 import { enemyIdParser } from '$/service/idParsers';
 import { randomUUID } from 'crypto';
 
@@ -43,7 +44,7 @@ export const enemyUseCase = {
     const newEnemy = await enemyRepository.create({
       id: enemyIdParser.parse(randomUUID()),
       direction: {
-        x: 2 * (Math.random() > 0.5 ? 1 : -1),
+        x: (Math.random() > 0.5 ? 1 : -1) * 0.5,
         y: 0,
       },
       createdPos: {
@@ -74,9 +75,10 @@ export const enemyUseCase = {
 
     await Promise.all(
       currentEnemyList.map((enemy) => {
-        // if (outOfDisplay(enemy.pos)) {
-        //   return enemyRepository.delete(enemy.id);
-        // }
+        const pos = computePosition(enemy);
+        if (outOfDisplay(pos)) {
+          return enemyRepository.delete(enemy.id);
+        }
       })
     );
   },

--- a/server/usecase/gameUseCase.ts
+++ b/server/usecase/gameUseCase.ts
@@ -5,6 +5,7 @@ export const gameUseCase = {
     const game = await gameRepository.find();
     return game?.displayNumber ?? null;
   },
+
   update: async (displayNumber: number) => {
     const game = await gameRepository.find();
     if (game === null) return;

--- a/server/usecase/playerUsecase.ts
+++ b/server/usecase/playerUsecase.ts
@@ -1,5 +1,5 @@
-import { SCREEN_HEIGHT, SCREEN_WIDTH } from '$/commonConstantsWithClient';
 import { randomUUID } from 'crypto';
+import { SCREEN_HEIGHT, SCREEN_WIDTH } from '../commonConstantsWithClient';
 import type { UserId } from '../commonTypesWithClient/branded';
 import type { PlayerModel } from '../commonTypesWithClient/models';
 import { gameRepository } from '../repository/gameRepository';

--- a/server/usecase/playerUsecase.ts
+++ b/server/usecase/playerUsecase.ts
@@ -1,6 +1,5 @@
-import assert from 'assert';
+import { SCREEN_HEIGHT, SCREEN_WIDTH } from '$/commonConstantsWithClient';
 import { randomUUID } from 'crypto';
-import { z } from 'zod';
 import type { UserId } from '../commonTypesWithClient/branded';
 import type { PlayerModel } from '../commonTypesWithClient/models';
 import { gameRepository } from '../repository/gameRepository';
@@ -9,112 +8,94 @@ import { userIdParser } from '../service/idParsers';
 
 export type MoveDirection = { x: number; y: number };
 
-// eslint-disable-next-line complexity
-const judgment = async (currentPlayerInfo: PlayerModel, newPos: { x: number; y: number }) => {
-  const displayNUmber = (await gameRepository.find().then((game) => game?.displayNumber)) ?? 1;
-  if (
-    (currentPlayerInfo.side === 'left' && newPos.x > 1920 * displayNUmber) ||
-    (currentPlayerInfo.side === 'right' && newPos.x < 0)
-  ) {
-    playerUseCase.finishGame(currentPlayerInfo);
-    return null;
-  }
-};
-//moveDirectionの値をzodでバリデーションする
-const MoveDirectionSchema = z.object({
-  x: z.number().min(-1).max(1),
-  y: z.number().min(-1).max(1),
-});
 export const playerUseCase = {
-  create: async (name: string, teamInfo: number): Promise<PlayerModel> => {
-    //playerの初期ステータス(デバッグ用)
-    console.log(teamInfo);
-    if (teamInfo === 1) {
-      const playerData: PlayerModel = {
-        userId: userIdParser.parse(randomUUID()),
-        pos: { x: 50, y: 300 },
-        name,
-        score: 0,
-        vector: { x: 5, y: 5 },
-        Items: [],
-        side: 'left',
-        isPlaying: true,
-      };
-      await playerRepository.save(playerData);
-      return playerData;
-    } else {
-      const playerData: PlayerModel = {
-        userId: userIdParser.parse(randomUUID()),
-        pos: { x: 1300, y: 300 },
-        name,
-        score: 0,
-        vector: { x: 5, y: 5 },
-        Items: [],
-        side: 'right',
-        isPlaying: true,
-      };
-      await playerRepository.save(playerData);
-      return playerData;
-    }
+  create: async (name: string): Promise<PlayerModel> => {
+    const [leftCount, rightCount] = await Promise.all([
+      playerRepository.countInSide('left'),
+      playerRepository.countInSide('right'),
+    ]);
+
+    const playerData: PlayerModel = {
+      id: userIdParser.parse(randomUUID()),
+      pos: { x: 50, y: SCREEN_HEIGHT / 2 },
+      name,
+      score: 0,
+      Items: [],
+      side: leftCount <= rightCount ? 'left' : 'right',
+      isPlaying: true,
+    };
+
+    return await playerRepository.save(playerData);
   },
+
   move: async (moveDirection: MoveDirection, userId: UserId): Promise<PlayerModel | null> => {
-    const currentPlayerInfo = await playerRepository.find(userId);
-    if (currentPlayerInfo === null) return null;
-    const validatedMoveDirection = MoveDirectionSchema.parse(moveDirection);
+    const displayNumber = (await gameRepository.find().then((game) => game?.displayNumber)) ?? 1;
+    const isOutOfDisplay = (
+      pos: { x: number; y: number },
+      side: 'left' | 'right',
+      displayNumber: number
+    ) => {
+      const terms = [
+        side === 'left' && pos.x > 1920 * displayNumber,
+        side === 'right' && pos.x < 0,
+      ];
+      return terms.some(Boolean);
+    };
+
+    const currentPlayer = await playerRepository.find(userId);
+    if (currentPlayer === null) return null;
 
     const newPos = {
-      x: currentPlayerInfo.pos.x + validatedMoveDirection.x * currentPlayerInfo.vector.x,
-      y: currentPlayerInfo.pos.y + validatedMoveDirection.y * currentPlayerInfo.vector.y,
+      x: Math.min(
+        Math.max(currentPlayer.pos.x + moveDirection.x * 5, 0),
+        SCREEN_WIDTH * displayNumber
+      ),
+      y: Math.min(Math.max(currentPlayer.pos.y + moveDirection.y * 5, 0), SCREEN_HEIGHT),
     };
-    if (judgment(currentPlayerInfo, newPos) === null) return null;
+
+    if (isOutOfDisplay(newPos, currentPlayer.side, displayNumber)) {
+      await playerUseCase.finishGame(currentPlayer);
+      return null;
+    }
     const updatePlayerInfo: PlayerModel = {
-      ...currentPlayerInfo,
+      ...currentPlayer,
       pos: newPos,
     };
-    await playerRepository.save(updatePlayerInfo);
-    return updatePlayerInfo;
+
+    return await playerRepository.save(updatePlayerInfo);
   },
+
   addScore: async (userId: UserId, score: number): Promise<PlayerModel | null> => {
-    const currentPlayerInfo = await playerRepository.find(userId);
-    assert(currentPlayerInfo);
+    const currentPlayer = await playerRepository.find(userId);
+    if (currentPlayer === null) return null;
+
     const updatePlayerInfo: PlayerModel = {
-      ...currentPlayerInfo,
-      score: currentPlayerInfo.score + score,
+      ...currentPlayer,
+      score: currentPlayer.score + score,
     };
-    await playerRepository.save(updatePlayerInfo);
-    return updatePlayerInfo;
-  },
-  getStatus: async (userId: UserId) => {
-    const currentPlayerInfo = await playerRepository.find(userId);
-    if (currentPlayerInfo === null) return null;
-    return currentPlayerInfo;
+
+    return await playerRepository.save(updatePlayerInfo);
   },
 
   finishGame: async (currentPlayerInfo: PlayerModel) => {
-    if (currentPlayerInfo === null) return null;
     const updatePlayerInfo: PlayerModel = {
       ...currentPlayerInfo,
       isPlaying: false,
     };
 
-    await playerRepository.save(updatePlayerInfo);
+    return await playerRepository.save(updatePlayerInfo);
+  },
 
-    return updatePlayerInfo;
-  },
-  getAllStatus: async () => {
-    return await playerRepository.findAll();
-  },
-  getPlayersByDisplayNumber: async (displayNumber: number) => {
+  getPlayersInDisplay: async (displayNumber: number) => {
+    const isInDisplay = (posX: number, displayNumber: number) => {
+      return Math.floor(posX / SCREEN_WIDTH) === displayNumber;
+    };
     const players = await playerRepository.findAll();
-    const playersByDisplayNumber = players.filter((player) => {
-      if (typeof player.pos.x === 'number' && player.isPlaying) {
-        return Math.floor(player.pos.x / 1920) === displayNumber;
-      }
-      return [];
+
+    const playersInDisplay = players.filter((player) => {
+      return isInDisplay(player.pos.x, displayNumber) && player.isPlaying;
     });
-    return playersByDisplayNumber;
+
+    return playersInDisplay;
   },
-  // getIsPlayingPlayer: async () => {
-  //   return await playerRepository.findPlayingOrDead(true);
-  // },
 };


### PR DESCRIPTION
## 内容

様々な処理にかかる時間を計測した結果、DB周りがボトルネックになっていたので、bulletやenemyのPositionをDBに保存せず、発射地点と発車時刻と方向から計算する実装に変更した

## 変更点

- DBのschemeの変更
- BEの処理の修正

## 関連 Issue

<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くとPRがマージされた際に自動的にIssueが閉じられます。
（例）
ref #0
close #0
-->

## スクリーンショット・動画など

![image](https://github.com/INIAD-Developers/Gradius-2023/assets/131662659/e947a102-2fb0-4cf1-994d-7b8ba8191792)

## その他
上の画像のように弾が大量にある時、以前までは処理落ちしていましたが問題なく動くようになった