### PR TITLE
modelsの変更漏れとそれにあわせた諸変更

### DIFF
--- a/client/src/components/Entity/Player.tsx
+++ b/client/src/components/Entity/Player.tsx
@@ -16,12 +16,12 @@ export const Player = ({ displayPosition: displayNumber, player }: Props) => {
   const relativePos = useMemo(() => {
     return {
       x:
-        player.pos.x -
+        player.x -
         displayNumber * SCREEN_WIDTH +
         PLAYER_HALF_WIDTH * (player.side === 'left' ? 1 : -1),
-      y: player.pos.y + PLAYER_HALF_WIDTH * (player.side === 'left' ? -1 : 1),
+      y: player.y + PLAYER_HALF_WIDTH * (player.side === 'left' ? -1 : 1),
     };
-  }, [displayNumber, player.pos.x, player.pos.y, player.side]);
+  }, [displayNumber, player.x, player.y, player.side]);
 
   const rotation = useMemo(() => {
     return player.side === 'left' ? 90 : -90;

--- a/server/commonTypesWithClient/models.ts
+++ b/server/commonTypesWithClient/models.ts
@@ -22,10 +22,8 @@ export type GameModel = {
 export type PlayerModel = {
   id: UserId;
   name: string;
-  pos: {
-    x: number;
-    y: number;
-  };
+  x: number;
+  y: number;
   score: number;
   Items:
     | {
@@ -63,5 +61,5 @@ export type BulletModel = {
   };
   createdAt: number;
   side: 'left' | 'right';
-  shooterId: string;
+  shooterId: UserId;
 };

--- a/server/repository/playerRepository.ts
+++ b/server/repository/playerRepository.ts
@@ -9,15 +9,8 @@ const toPlayerModel = (prismaPlayer: Player): PlayerModel => ({
   id: userIdParser.parse(prismaPlayer.userId),
   name: z.string().parse(prismaPlayer.name),
   score: z.number().parse(prismaPlayer.score),
-  pos: z
-    .object({
-      x: z.number(),
-      y: z.number(),
-    })
-    .parse({
-      x: prismaPlayer.x,
-      y: prismaPlayer.y,
-    }),
+  x: z.number().parse(prismaPlayer.x),
+  y: z.number().parse(prismaPlayer.y),
   Items:
     z
       .object({
@@ -40,8 +33,8 @@ export const playerRepository = {
       update: {
         score: player.score,
         Item: player.Items,
-        x: player.pos.x,
-        y: player.pos.y,
+        x: player.x,
+        y: player.y,
         isPlaying: player.isPlaying,
       },
       create: {
@@ -49,8 +42,8 @@ export const playerRepository = {
         name: player.name,
         score: player.score,
         Item: player.Items,
-        x: player.pos.x,
-        y: player.pos.y,
+        x: player.x,
+        y: player.y,
         side: player.side,
         isPlaying: player.isPlaying,
       },

--- a/server/service/computePositions.ts
+++ b/server/service/computePositions.ts
@@ -1,7 +1,9 @@
 import type { BulletModel, EnemyModel, PlayerModel } from '$/commonTypesWithClient/models';
 
 export const computePosition = (entity: PlayerModel | EnemyModel | BulletModel) => {
-  if ('pos' in entity) return entity.pos;
+  if ('name' in entity) {
+    return { x: entity.x, y: entity.y };
+  }
 
   const now = Date.now();
   const timeDiff = now - entity.createdAt;

--- a/server/usecase/bulletUsecase.ts
+++ b/server/usecase/bulletUsecase.ts
@@ -36,8 +36,8 @@ export const bulletUseCase = {
         y: 0,
       },
       createdPos: {
-        x: shooterInfo.pos.x + PLAYER_HALF_WIDTH * (shooterInfo.side === 'left' ? -1 : 1),
-        y: shooterInfo.pos.y,
+        x: shooterInfo.x + PLAYER_HALF_WIDTH * (shooterInfo.side === 'left' ? -1 : 1),
+        y: shooterInfo.y,
       },
       createdAt: Date.now(),
       side: shooterInfo.side,

--- a/server/usecase/collisionUsecase.ts
+++ b/server/usecase/collisionUsecase.ts
@@ -20,8 +20,6 @@ let intervalId: NodeJS.Timeout | null = null;
 const givePosition = (entity: EntityModel) => {
   const pos = computePosition(entity);
 
-  if ('pos' in entity) return entity;
-
   return {
     ...entity,
     pos,

--- a/server/usecase/playerUsecase.ts
+++ b/server/usecase/playerUsecase.ts
@@ -17,7 +17,8 @@ export const playerUseCase = {
 
     const playerData: PlayerModel = {
       id: userIdParser.parse(randomUUID()),
-      pos: { x: 50, y: SCREEN_HEIGHT / 2 },
+      x: 50,
+      y: SCREEN_HEIGHT / 2,
       name,
       score: 0,
       Items: [],
@@ -46,11 +47,8 @@ export const playerUseCase = {
     if (currentPlayer === null) return null;
 
     const newPos = {
-      x: Math.min(
-        Math.max(currentPlayer.pos.x + moveDirection.x * 5, 0),
-        SCREEN_WIDTH * displayNumber
-      ),
-      y: Math.min(Math.max(currentPlayer.pos.y + moveDirection.y * 5, 0), SCREEN_HEIGHT),
+      x: Math.min(Math.max(currentPlayer.x + moveDirection.x * 5, 0), SCREEN_WIDTH * displayNumber),
+      y: Math.min(Math.max(currentPlayer.y + moveDirection.y * 5, 0), SCREEN_HEIGHT),
     };
 
     if (isOutOfDisplay(newPos, currentPlayer.side, displayNumber)) {
@@ -59,7 +57,8 @@ export const playerUseCase = {
     }
     const updatePlayerInfo: PlayerModel = {
       ...currentPlayer,
-      pos: newPos,
+      x: newPos.x,
+      y: newPos.y,
     };
 
     return await playerRepository.save(updatePlayerInfo);
@@ -88,7 +87,7 @@ export const playerUseCase = {
     const players = await playerRepository.findAll();
 
     const playersInDisplay = players.filter((player) => {
-      return isInDisplay(player.pos.x, displayNumber) && player.isPlaying;
+      return isInDisplay(player.x, displayNumber) && player.isPlaying;
     });
 
     return playersInDisplay;


### PR DESCRIPTION
## 内容

スキーマを書き換えたときplayerはposではなくxとyを持つようになったが
playerModelがそれに対応していなかったので変更し、それに伴ってほかのところを修正した

## 変更点

１，playerModelがposの連想配列からxとyをそれぞれ持つように（スキーマに合わせた）
２，それにあわせてplayerのposを使っていたところを修正

## 関連 Issue

#91 