### PR TITLE
game画面上の問題を修正

### DIFF
--- a/client/src/components/Effect/Boom.tsx
+++ b/client/src/components/Effect/Boom.tsx
@@ -1,12 +1,13 @@
 import { ENEMY_HALF_WIDTH, SCREEN_WIDTH } from 'commonConstantsWithClient';
 import { useEffect, useState } from 'react';
 import { Image } from 'react-konva';
+import type { Pos } from 'src/types/types';
 import { staticPath } from 'src/utils/$path';
 import useImage from 'use-image';
 
 type Props = {
   displayPosition: number;
-  position: number[];
+  position: Pos;
 };
 
 const Boom = ({ displayPosition, position }: Props) => {
@@ -31,8 +32,8 @@ const Boom = ({ displayPosition, position }: Props) => {
   const [currentImageIndex, setCurrentImageIndex] = useState(0);
 
   const relativePos = {
-    x: position[0] - displayPosition * SCREEN_WIDTH,
-    y: position[1],
+    x: position.x - displayPosition * SCREEN_WIDTH,
+    y: position.y,
   };
 
   useEffect(() => {

--- a/client/src/components/Entity/Bullet.tsx
+++ b/client/src/components/Entity/Bullet.tsx
@@ -9,15 +9,16 @@ import useImage from 'use-image';
 type Props = {
   displayPosition: number;
   bullet: BulletModel;
+  timeDiffFix: number;
 };
 
-export const Bullet = ({ displayPosition, bullet }: Props) => {
+export const Bullet = ({ displayPosition, bullet, timeDiffFix }: Props) => {
   const [bulletImage1] = useImage(staticPath.images.entity.bullet_red_png);
   const [bulletImage2] = useImage(staticPath.images.entity.bullet_blue_png);
 
   const images = [bulletImage1, bulletImage2];
 
-  const pos = computePosition(bullet.createdPos, bullet.createdAt, bullet.direction);
+  const pos = computePosition(bullet.createdPos, bullet.createdAt, bullet.direction, timeDiffFix);
 
   const ownerType = useMemo(() => {
     return bullet.side === 'left' ? 0 : 1;

--- a/client/src/components/Entity/Enemy.tsx
+++ b/client/src/components/Entity/Enemy.tsx
@@ -9,16 +9,17 @@ import useImage from 'use-image';
 type Props = {
   displayPosition: number;
   enemy: EnemyModel;
+  timeDiffFix: number;
 };
 
-export const Enemy = ({ displayPosition, enemy }: Props) => {
+export const Enemy = ({ displayPosition, enemy, timeDiffFix }: Props) => {
   const [enemyImage1] = useImage(staticPath.images.entity.ufo_1_png);
   const [enemyImage2] = useImage(staticPath.images.entity.ufo_2_png);
   const [enemyImage3] = useImage(staticPath.images.entity.ufo_3_png);
 
   const images = [enemyImage1, enemyImage2, enemyImage3];
 
-  const pos = computePosition(enemy.createdPos, enemy.createdAt, enemy.direction);
+  const pos = computePosition(enemy.createdPos, enemy.createdAt, enemy.direction, timeDiffFix);
 
   const relativePos = useMemo(() => {
     return {

--- a/client/src/components/traffic/traffic.tsx
+++ b/client/src/components/traffic/traffic.tsx
@@ -1,20 +1,20 @@
 import { useEffect, useState } from 'react';
 import styles from './traffic.module.css';
 
-export const Traffic = ({
-  traffic,
-  width,
-  length,
-}: {
+type props = {
   traffic: number;
   width: number;
   length: number;
-}) => {
+};
+
+export const Traffic = ({ traffic, width, length }: props) => {
   const [traffics, setTraffics] = useState([0]);
   const [update, setUpdate] = useState(true);
+
   useEffect(() => {
     if (update) setTraffics([...traffics.slice(-length + 1), traffic]);
   }, [setTraffics, traffic, traffics, update, length]);
+
   return (
     <div className={styles.container} style={{ width }}>
       <div

--- a/client/src/pages/controller/index.page.tsx
+++ b/client/src/pages/controller/index.page.tsx
@@ -6,14 +6,10 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Joystick } from 'react-joystick-component';
 import type { IJoystickUpdateEvent } from 'react-joystick-component/build/lib/Joystick';
 import GameClear from 'src/components/GameClear/GameClear';
+import type { Pos } from 'src/types/types';
 import { apiClient } from 'src/utils/apiClient';
 import { getUserIdFromLocalStorage, logoutWithLocalStorage } from 'src/utils/loginWithLocalStorage';
 import styles from './index.module.css';
-
-type MoveTo = {
-  x: number;
-  y: number;
-};
 
 const Home = () => {
   const [windowsize, setWindowsize] = useState<{ width: number; height: number }>({
@@ -24,7 +20,7 @@ const Home = () => {
   const [playerStatus, setPlayerStatus] = useState<PlayerModel>();
 
   const [moveIntervalId, setMoveIntervalId] = useState<NodeJS.Timeout[]>([]);
-  const moveDirection = useRef<MoveTo>({ x: 0, y: 0 });
+  const moveDirection = useRef<Pos>({ x: 0, y: 0 });
   const [shootIntervalId, setShootIntervalId] = useState<NodeJS.Timeout[]>([]);
   const router = useRouter();
   const MOVE_INTERVAL_TIME = 20;

--- a/client/src/pages/game/[displayPosition]/index.page.tsx
+++ b/client/src/pages/game/[displayPosition]/index.page.tsx
@@ -78,11 +78,11 @@ const Game = () => {
   };
 
   const fetchDiff = async () => {
-    const frontTIme = Date.now();
+    const frontTime = Date.now();
 
     const res = await apiClient.diff.$get();
 
-    setTimeDiffFix(res - frontTIme);
+    setTimeDiffFix(res - frontTime);
   };
 
   //ANCHOR - effect

--- a/client/src/pages/game/[displayPosition]/index.page.tsx
+++ b/client/src/pages/game/[displayPosition]/index.page.tsx
@@ -32,7 +32,7 @@ const Game = () => {
   const [enemies, setEnemies] = useState<EnemyModel[]>([]);
   const [bullets, setBullets] = useState<BulletModel[]>([]);
   //TODO: もし、これ以外のエフェクトを追加する場合は、それぞれのエフェクトを区別する型を作成する
-  const [effectPosition, setEffectPosition] = useState<number[][]>([]);
+  const [effectPosition, setEffectPosition] = useState<number[][][]>([[[]]]);
   const [windowSize, setWindowSize] = useState<WindowSize>({
     width: window.innerWidth,
     height: window.innerHeight,
@@ -50,15 +50,13 @@ const Game = () => {
   const fetchEnemies = async () => {
     const res = await apiClient.enemy.$get();
     const killedEnemies = enemies.filter((enemy) => !res.some((e) => e.id === enemy.id));
-    if (killedEnemies.length > 0) {
-      killedEnemies.forEach((enemy) => {
-        const pos = computePosition(enemy.createdPos, enemy.createdAt, enemy.direction);
-        setEffectPosition((prev) => [
-          ...prev,
-          [pos.x - ENEMY_HALF_WIDTH, pos.y - ENEMY_HALF_WIDTH],
-        ]);
-      });
-    }
+    // if (killedEnemies.length > 0) {
+    const newEffectPosition = killedEnemies.map((enemy) => {
+      const pos = computePosition(enemy.createdPos, enemy.createdAt, enemy.direction);
+      return [pos.x - ENEMY_HALF_WIDTH, pos.y - ENEMY_HALF_WIDTH];
+    });
+    setEffectPosition((prev) => [...prev.slice(-10), newEffectPosition]);
+    // }
     setEnemies(res);
   };
 
@@ -149,7 +147,7 @@ const Game = () => {
           ))}
         </Layer>
         <Layer>
-          {effectPosition.map((position, index) => (
+          {effectPosition.flat().map((position, index) => (
             <Boom displayPosition={displayPosition ?? 0} position={position} key={index} />
           ))}
         </Layer>

--- a/client/src/pages/game/[displayPosition]/index.page.tsx
+++ b/client/src/pages/game/[displayPosition]/index.page.tsx
@@ -117,7 +117,7 @@ const Game = () => {
 
   useEffect(() => {
     fetchDiff();
-  },[]);
+  }, []);
 
   //ANCHOR - return
   return (

--- a/client/src/pages/game/[displayPosition]/index.page.tsx
+++ b/client/src/pages/game/[displayPosition]/index.page.tsx
@@ -50,13 +50,13 @@ const Game = () => {
   const fetchEnemies = async () => {
     const res = await apiClient.enemy.$get();
     const killedEnemies = enemies.filter((enemy) => !res.some((e) => e.id === enemy.id));
-    // if (killedEnemies.length > 0) {
+
     const newEffectPosition = killedEnemies.map((enemy) => {
       const pos = computePosition(enemy.createdPos, enemy.createdAt, enemy.direction);
       return [pos.x - ENEMY_HALF_WIDTH, pos.y - ENEMY_HALF_WIDTH];
     });
     setEffectPosition((prev) => [...prev.slice(-10), newEffectPosition]);
-    // }
+
     setEnemies(res);
   };
 

--- a/client/src/pages/game/[displayPosition]/index.page.tsx
+++ b/client/src/pages/game/[displayPosition]/index.page.tsx
@@ -7,16 +7,12 @@ import Boom from 'src/components/Effect/Boom';
 import { Bullet } from 'src/components/Entity/Bullet';
 import { Enemy } from 'src/components/Entity/Enemy';
 import { Player } from 'src/components/Entity/Player';
+import type { Pos, WindowSize } from 'src/types/types';
 import { staticPath } from 'src/utils/$path';
 import { apiClient } from 'src/utils/apiClient';
 import { computePosition } from 'src/utils/computePosition';
 import useImage from 'use-image';
 import styles from './index.module.css';
-
-type WindowSize = {
-  width: number;
-  height: number;
-};
 
 const Game = () => {
   const router = useRouter();
@@ -36,7 +32,7 @@ const Game = () => {
   const [timeDiffFix, setTimeDiffFix] = useState<number>();
 
   //TODO: もし、これ以外のエフェクトを追加する場合は、それぞれのエフェクトを区別する型を作成する
-  const [effectPosition, setEffectPosition] = useState<number[][][]>([[[]]]);
+  const [effectPosition, setEffectPosition] = useState<Pos[][]>([[]]);
   const [windowSize, setWindowSize] = useState<WindowSize>({
     width: window.innerWidth,
     height: window.innerHeight,
@@ -63,7 +59,7 @@ const Game = () => {
         enemy.direction,
         timeDiffFix ?? 0
       );
-      return [pos.x - ENEMY_HALF_WIDTH, pos.y - ENEMY_HALF_WIDTH];
+      return { x: pos.x - ENEMY_HALF_WIDTH, y: pos.y - ENEMY_HALF_WIDTH };
     });
     setEffectPosition((prev) => [...prev.slice(-10), newEffectPosition]);
 

--- a/client/src/pages/game/[displayPosition]/index.page.tsx
+++ b/client/src/pages/game/[displayPosition]/index.page.tsx
@@ -117,7 +117,7 @@ const Game = () => {
 
   useEffect(() => {
     fetchDiff();
-  });
+  },[]);
 
   //ANCHOR - return
   return (

--- a/client/src/pages/qrcode/index.page.tsx
+++ b/client/src/pages/qrcode/index.page.tsx
@@ -1,17 +1,13 @@
 import { useQRCode } from 'next-qrcode';
 import { useEffect, useState } from 'react';
+import type { WindowSize } from 'src/types/types';
 import { apiClient } from 'src/utils/apiClient';
 import styles from './index.module.css';
-
-type Size = {
-  width: number;
-  height: number;
-};
 
 const QRCode = () => {
   const [ip, setIp] = useState<string>('');
   const [isSimple, setIsSimple] = useState<boolean>(true);
-  const [windowSize, setWindowSize] = useState<Size>({
+  const [windowSize, setWindowSize] = useState<WindowSize>({
     width: window.innerWidth,
     height: window.innerHeight,
   });

--- a/client/src/types/types.ts
+++ b/client/src/types/types.ts
@@ -1,0 +1,9 @@
+export type WindowSize = {
+  width: number;
+  height: number;
+};
+
+export type Pos = {
+  x: number;
+  y: number;
+};

--- a/client/src/utils/computePosition.ts
+++ b/client/src/utils/computePosition.ts
@@ -1,7 +1,4 @@
-type Pos = {
-  x: number;
-  y: number;
-};
+import type { Pos } from 'src/types/types';
 
 export const computePosition = (
   createdPos: Pos,

--- a/client/src/utils/computePosition.ts
+++ b/client/src/utils/computePosition.ts
@@ -3,11 +3,15 @@ type Pos = {
   y: number;
 };
 
-export const computePosition = (createdPos: Pos, createdAt: number, direction: Pos) => {
+export const computePosition = (
+  createdPos: Pos,
+  createdAt: number,
+  direction: Pos,
+  timeDiffFix: number
+) => {
   const now = Date.now();
-  const timeDiff = now - createdAt;
+  const timeDiff = now - createdAt + timeDiffFix;
   const distance = (timeDiff / 1000) * 300;
-
   return {
     x: createdPos.x + direction.x * distance,
     y: createdPos.y + direction.y * distance,

--- a/server/api/diff/controller.ts
+++ b/server/api/diff/controller.ts
@@ -1,0 +1,5 @@
+import { defineController } from './$relay';
+
+export default defineController(() => ({
+  get: () => ({ status: 200, body: Date.now() }),
+}));

--- a/server/api/diff/index.ts
+++ b/server/api/diff/index.ts
@@ -1,0 +1,7 @@
+import type { DefineMethods } from 'aspida';
+
+export type Methods = DefineMethods<{
+  get: {
+    resBody: number;
+  };
+}>;

--- a/server/usecase/bulletUsecase.ts
+++ b/server/usecase/bulletUsecase.ts
@@ -36,7 +36,7 @@ export const bulletUseCase = {
         y: 0,
       },
       createdPos: {
-        x: shooterInfo.pos.x + PLAYER_HALF_WIDTH * (shooterInfo.side === 'left' ? -1 : 1),
+        x: shooterInfo.pos.x + PLAYER_HALF_WIDTH * (shooterInfo.side === 'left' ? 1 : -1),
         y: shooterInfo.pos.y,
       },
       createdAt: Date.now(),

--- a/server/usecase/collisionUsecase.ts
+++ b/server/usecase/collisionUsecase.ts
@@ -11,6 +11,7 @@ import { enemyRepository } from '$/repository/enemyRepository';
 import { gameRepository } from '$/repository/gameRepository';
 import { playerRepository } from '$/repository/playerRepository';
 import { computePosition } from '$/service/computePositions';
+import { userIdParser } from '$/service/idParsers';
 import { playerUseCase } from './playerUsecase';
 
 type EntityModel = PlayerModel | EnemyModel | BulletModel;
@@ -142,12 +143,18 @@ const checkCollisions = async () => {
     });
   });
 
+  const deleteBulletAndAddScore = (entity: BulletModel) => {
+    bulletRepository.delete(entity.id);
+    playerUseCase.addScore(userIdParser.parse(entity.shooterId), 150);
+    console.log('kill!');
+  };
+
   await Promise.all(
     collisions.map((entity) => {
       if ('score' in entity) {
         return playerUseCase.addScore(entity.id, -100);
       } else if ('side' in entity) {
-        return bulletRepository.delete(entity.id);
+        return deleteBulletAndAddScore(entity);
       } else {
         return enemyRepository.delete(entity.id);
       }


### PR DESCRIPTION
## 内容

爆発エフェクトのせいで時間がたつと重くなる問題を修正
敵の表示上の位置と内部データ上の位置が異なる問題を修正

## 変更点

- エフェクトを表示する用の配列を`{x: number; y:number}`の配列とし、古い要素をスライスしていく
- IPアドレス経由で表示するとディスプレイのPCの時間とサーバーのPCの時間にかなりのずれが生じるので記録して補正

## 関連 Issue

close #104 