### PR TITLE
弾発射音がコントローラー画面で流れるように、hooksに分割

### DIFF
--- a/client/src/pages/@hooks/usePlayerControl.ts
+++ b/client/src/pages/@hooks/usePlayerControl.ts
@@ -1,0 +1,114 @@
+import type { UserId } from 'commonTypesWithClient/branded';
+import { useEffect, useRef, useState } from 'react';
+import type { IJoystickUpdateEvent } from 'react-joystick-component/build/lib/Joystick';
+import type { Pos } from 'src/types/types';
+import { staticPath } from 'src/utils/$path';
+import { apiClient } from 'src/utils/apiClient';
+
+export const usePlayerControl = (userId: UserId) => {
+  const [moveIntervalId, setMoveIntervalId] = useState<NodeJS.Timeout[]>([]);
+  const moveDirection = useRef<Pos>({ x: 0, y: 0 });
+  const [shootIntervalId, setShootIntervalId] = useState<NodeJS.Timeout[]>([]);
+  const MOVE_INTERVAL_TIME = 20;
+  const SHOOT_INTERVAL_TIME = 1000;
+  const [isButtonActive, setButtonActive] = useState(false);
+  const shootAudio = new Audio(staticPath.sounds.shot_mp3);
+  const [shootBoolean, setShootBoolean] = useState(true);
+  const shootBullet = async () => {
+    if (shootBoolean) {
+      const audio = shootAudio.cloneNode() as HTMLAudioElement;
+      audio.play();
+      await apiClient.bullet.$post({
+        body: {
+          userId,
+        },
+      });
+      setShootBoolean(false);
+    }
+  };
+
+  const startShoot = async () => {
+    setButtonActive(true);
+    const shootIntervalId = setInterval(async () => {
+      const audio = shootAudio.cloneNode() as HTMLAudioElement;
+      audio.play();
+      await apiClient.bullet.$post({
+        body: {
+          userId,
+        },
+      });
+    }, SHOOT_INTERVAL_TIME);
+    setShootIntervalId((prev) => [...prev, shootIntervalId]);
+  };
+  const stopShoot = () => {
+    setButtonActive(false);
+    shootIntervalId.forEach((id) => clearInterval(id));
+    setShootIntervalId([]);
+  };
+  const handelMove = (e: IJoystickUpdateEvent) => {
+    moveDirection.current = {
+      x: e.x ?? 0,
+      y: (e.y ?? 0) * -1,
+    };
+  };
+  const startMove = () => {
+    const moveIntervalId = setInterval(async () => {
+      await apiClient.player.control.$post({
+        body: {
+          userId,
+          MoveDirection: moveDirection.current,
+        },
+      });
+    }, MOVE_INTERVAL_TIME);
+    setMoveIntervalId((prev) => [...prev, moveIntervalId]);
+  };
+  const stopMove = () => {
+    moveDirection.current = { x: 0, y: 0 };
+    moveIntervalId.forEach((id) => clearInterval(id));
+    setMoveIntervalId([]);
+  };
+
+  useEffect(() => {
+    const bulletInterval = setInterval(() => {
+      setShootBoolean(true);
+    }, SHOOT_INTERVAL_TIME);
+    return () => {
+      clearInterval(bulletInterval);
+    };
+  }, [shootBoolean]);
+
+  useEffect(() => {
+    document.body.addEventListener(
+      'touchstart',
+      (e) => {
+        e.preventDefault();
+      },
+      { passive: false }
+    );
+    document.body.addEventListener(
+      'touchmove',
+      (e) => {
+        e.preventDefault();
+      },
+      { passive: false }
+    );
+
+    return () => {
+      document.body.removeEventListener('touchstart', (e) => {
+        e.preventDefault();
+      });
+      document.body.removeEventListener('touchmove', (e) => {
+        e.preventDefault();
+      });
+    };
+  }, []);
+  return {
+    startMove,
+    stopMove,
+    startShoot,
+    stopShoot,
+    handelMove,
+    shootBullet,
+    isButtonActive,
+  };
+};

--- a/client/src/pages/@hooks/usePlayerControl.ts
+++ b/client/src/pages/@hooks/usePlayerControl.ts
@@ -5,15 +5,18 @@ import type { Pos } from 'src/types/types';
 import { staticPath } from 'src/utils/$path';
 import { apiClient } from 'src/utils/apiClient';
 
+const MOVE_INTERVAL_TIME = 20;
+const SHOOT_INTERVAL_TIME = 1000;
+
 export const usePlayerControl = (userId: UserId) => {
   const [moveIntervalId, setMoveIntervalId] = useState<NodeJS.Timeout[]>([]);
   const moveDirection = useRef<Pos>({ x: 0, y: 0 });
+
   const [shootIntervalId, setShootIntervalId] = useState<NodeJS.Timeout[]>([]);
-  const MOVE_INTERVAL_TIME = 20;
-  const SHOOT_INTERVAL_TIME = 1000;
-  const [isButtonActive, setButtonActive] = useState(false);
   const shootAudio = new Audio(staticPath.sounds.shot_mp3);
   const [shootBoolean, setShootBoolean] = useState(true);
+  const [isButtonActive, setButtonActive] = useState(false);
+
   const shootBullet = async () => {
     if (shootBoolean) {
       const audio = shootAudio.cloneNode() as HTMLAudioElement;
@@ -40,17 +43,20 @@ export const usePlayerControl = (userId: UserId) => {
     }, SHOOT_INTERVAL_TIME);
     setShootIntervalId((prev) => [...prev, shootIntervalId]);
   };
+
   const stopShoot = () => {
     setButtonActive(false);
     shootIntervalId.forEach((id) => clearInterval(id));
     setShootIntervalId([]);
   };
+
   const handelMove = (e: IJoystickUpdateEvent) => {
     moveDirection.current = {
       x: e.x ?? 0,
       y: (e.y ?? 0) * -1,
     };
   };
+
   const startMove = () => {
     const moveIntervalId = setInterval(async () => {
       await apiClient.player.control.$post({
@@ -62,6 +68,7 @@ export const usePlayerControl = (userId: UserId) => {
     }, MOVE_INTERVAL_TIME);
     setMoveIntervalId((prev) => [...prev, moveIntervalId]);
   };
+
   const stopMove = () => {
     moveDirection.current = { x: 0, y: 0 };
     moveIntervalId.forEach((id) => clearInterval(id));
@@ -102,6 +109,7 @@ export const usePlayerControl = (userId: UserId) => {
       });
     };
   }, []);
+
   return {
     startMove,
     stopMove,

--- a/client/src/pages/@hooks/useWindowSize.ts
+++ b/client/src/pages/@hooks/useWindowSize.ts
@@ -18,5 +18,6 @@ export const useWindowSize = () => {
       window.removeEventListener('resize', handleResize);
     };
   }, []);
+
   return windowsize;
 };

--- a/client/src/pages/@hooks/useWindowSize.ts
+++ b/client/src/pages/@hooks/useWindowSize.ts
@@ -1,0 +1,22 @@
+import { useEffect, useState } from 'react';
+
+export const useWindowSize = () => {
+  const [windowsize, setWindowsize] = useState<{ width: number; height: number }>({
+    width: window.innerWidth,
+    height: window.innerHeight,
+  });
+
+  useEffect(() => {
+    const handleResize = () => {
+      setWindowsize({
+        width: window.innerWidth,
+        height: window.innerHeight,
+      });
+    };
+    window.addEventListener('resize', handleResize);
+    return () => {
+      window.removeEventListener('resize', handleResize);
+    };
+  }, []);
+  return windowsize;
+};

--- a/client/src/pages/controller/index.module.css
+++ b/client/src/pages/controller/index.module.css
@@ -68,11 +68,11 @@
 }
 
 .buttonActive::before {
-  animation: progress-left 0.8s linear infinite;
+  animation: progress-left 1s linear infinite;
 }
 
 .buttonActive::after {
-  animation: progress-right 0.8s linear infinite;
+  animation: progress-right 1s linear infinite;
 }
 
 .button > div {

--- a/client/src/pages/controller/index.page.tsx
+++ b/client/src/pages/controller/index.page.tsx
@@ -1,41 +1,25 @@
 import type { UserId } from 'commonTypesWithClient/branded';
 import type { PlayerModel } from 'commonTypesWithClient/models';
 import { useRouter } from 'next/router';
-import type { MouseEvent, TouchEvent } from 'react';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { Joystick } from 'react-joystick-component';
-import type { IJoystickUpdateEvent } from 'react-joystick-component/build/lib/Joystick';
 import GameClear from 'src/components/GameClear/GameClear';
-import type { Pos } from 'src/types/types';
 import { apiClient } from 'src/utils/apiClient';
 import { getUserIdFromLocalStorage, logoutWithLocalStorage } from 'src/utils/loginWithLocalStorage';
+import { usePlayerControl } from '../@hooks/usePlayerControl';
+import { useWindowSize } from '../@hooks/useWindowSize';
 import styles from './index.module.css';
 
 const Home = () => {
-  const [windowsize, setWindowsize] = useState<{ width: number; height: number }>({
-    width: window.innerWidth,
-    height: window.innerHeight,
-  });
+  const router = useRouter();
+  const windowSize = useWindowSize();
+
   const [userId, setUserId] = useState<UserId>('' as UserId);
+
+  const { startMove, stopMove, startShoot, stopShoot, handelMove, shootBullet, isButtonActive } =
+    usePlayerControl(userId);
   const [playerStatus, setPlayerStatus] = useState<PlayerModel>();
 
-  const [moveIntervalId, setMoveIntervalId] = useState<NodeJS.Timeout[]>([]);
-  const moveDirection = useRef<Pos>({ x: 0, y: 0 });
-  const [shootIntervalId, setShootIntervalId] = useState<NodeJS.Timeout[]>([]);
-  const router = useRouter();
-  const MOVE_INTERVAL_TIME = 20;
-  const SHOOT_INTERVAL_TIME = 1000;
-  const [shootBoolean, setShootBoolean] = useState(true);
-  const shootBullet = async () => {
-    if (shootBoolean) {
-      await apiClient.bullet.$post({
-        body: {
-          userId,
-        },
-      });
-      setShootBoolean(false);
-    }
-  };
   const getUserId = useCallback(async () => {
     const localStorageUserId = getUserIdFromLocalStorage();
     if (!(playerStatus?.isPlaying ?? true)) return;
@@ -45,69 +29,22 @@ const Home = () => {
     }
     setUserId(localStorageUserId);
   }, [router, playerStatus?.isPlaying]);
+
   const fetchPlayerStatus = useCallback(async () => {
     const res = await apiClient.player.control.$get({ query: { userId } });
     if (res === null) return;
     setPlayerStatus(res);
   }, [userId]);
-  const startShoot = async (e: TouchEvent<HTMLButtonElement> | MouseEvent<HTMLButtonElement>) => {
-    const target = e.target as HTMLElement;
-    const button = target.tagName === 'BUTTON' ? target : target.parentElement;
-    button?.classList.add(styles.buttonActive);
-    const shootIntervalId = setInterval(async () => {
-      await apiClient.bullet.$post({
-        body: {
-          userId,
-        },
-      });
-    }, SHOOT_INTERVAL_TIME);
-    setShootIntervalId((prev) => [...prev, shootIntervalId]);
-  };
-  const stopShoot = (e: TouchEvent<HTMLButtonElement> | MouseEvent<HTMLButtonElement>) => {
-    const target = e.target as HTMLElement;
-    const button = target.tagName === 'BUTTON' ? target : target.parentElement;
-    button?.classList.remove(styles.buttonActive);
-    shootIntervalId.forEach((id) => clearInterval(id));
-    setShootIntervalId([]);
-  };
-  const handelMove = (e: IJoystickUpdateEvent) => {
-    moveDirection.current = {
-      x: e.x ?? 0,
-      y: (e.y ?? 0) * -1,
-    };
-  };
-  const startMove = () => {
-    const moveIntervalId = setInterval(async () => {
-      await apiClient.player.control.$post({
-        body: {
-          userId,
-          MoveDirection: moveDirection.current,
-        },
-      });
-    }, MOVE_INTERVAL_TIME);
-    setMoveIntervalId((prev) => [...prev, moveIntervalId]);
-  };
-  const stopMove = () => {
-    moveDirection.current = { x: 0, y: 0 };
-    moveIntervalId.forEach((id) => clearInterval(id));
-    setMoveIntervalId([]);
-  };
+
   const joystickSize = useMemo(() => {
-    const aspectRatio = windowsize.width / windowsize.height;
+    const aspectRatio = windowSize.width / windowSize.height;
     if (aspectRatio > 3 / 4) {
-      return Math.min(windowsize.height, windowsize.width) * 0.5;
+      return Math.min(windowSize.height, windowSize.width) * 0.5;
     } else {
-      return windowsize.width * 0.5 * 0.64;
+      return windowSize.width * 0.5 * 0.64;
     }
-  }, [windowsize]);
-  useEffect(() => {
-    const bulletInterval = setInterval(() => {
-      setShootBoolean(true);
-    }, SHOOT_INTERVAL_TIME);
-    return () => {
-      clearInterval(bulletInterval);
-    };
-  }, [shootBoolean]);
+  }, [windowSize]);
+
   useEffect(() => {
     const userIdIntervalId = setInterval(() => {
       getUserId();
@@ -120,43 +57,6 @@ const Home = () => {
       clearInterval(playerStatusIntervalId);
     };
   }, [getUserId, fetchPlayerStatus]);
-  useEffect(() => {
-    const handleResize = () => {
-      setWindowsize({
-        width: window.innerWidth,
-        height: window.innerHeight,
-      });
-    };
-    window.addEventListener('resize', handleResize);
-    return () => {
-      window.removeEventListener('resize', handleResize);
-    };
-  }, []);
-  useEffect(() => {
-    document.body.addEventListener(
-      'touchstart',
-      (e) => {
-        e.preventDefault();
-      },
-      { passive: false }
-    );
-    document.body.addEventListener(
-      'touchmove',
-      (e) => {
-        e.preventDefault();
-      },
-      { passive: false }
-    );
-
-    return () => {
-      document.body.removeEventListener('touchstart', (e) => {
-        e.preventDefault();
-      });
-      document.body.removeEventListener('touchmove', (e) => {
-        e.preventDefault();
-      });
-    };
-  }, []);
 
   if (!(playerStatus?.isPlaying ?? true)) return <GameClear />;
 
@@ -177,7 +77,7 @@ const Home = () => {
         <button onClick={logoutWithLocalStorage}>logout</button>
       </div>
       <button
-        className={styles.button}
+        className={`${styles.button} ${isButtonActive ? styles.buttonActive : ''}`}
         onClick={shootBullet} //PCでクリックイベント
         onTouchEndCapture={shootBullet} //スマホでクリックイベント
         onTouchStart={startShoot}

--- a/client/src/pages/game/[displayPosition]/index.page.tsx
+++ b/client/src/pages/game/[displayPosition]/index.page.tsx
@@ -70,10 +70,6 @@ const Game = () => {
     const res = await apiClient.bullet.$get({
       query: { displayNumber: Number(displayPosition) },
     });
-    if (res.length > bullets.length) {
-      const audio = new Audio(staticPath.sounds.shot_mp3);
-      audio.play();
-    }
     setBullets(res);
   };
 


### PR DESCRIPTION
## 内容

弾発射音がコントローラー画面で流れるように
コントローラーの移動と発射のロジックをhooksに分割

## 変更点

１，弾発射音をコントローラー画面で流す
２，音の流し方を改良、音と同期するようにアニメーション調整
３，移動と発射のロジックをusePlayerControlに分割
４，windowサイズのロジックをuseWindowSizeに分割