### PR TITLE
gameディスプレイの見た目関連の実装

### DIFF
--- a/client/src/components/Effect/Boom.tsx
+++ b/client/src/components/Effect/Boom.tsx
@@ -57,8 +57,8 @@ const Boom = ({ displayPosition, position }: Props) => {
       image={boomImages[currentImageIndex]}
       x={relativePos.x}
       y={relativePos.y}
-      width={ENEMY_HALF_WIDTH * 2 * 1.2}
-      height={ENEMY_HALF_WIDTH * 2 * 1.2}
+      width={ENEMY_HALF_WIDTH * 1.8}
+      height={ENEMY_HALF_WIDTH * 1.8}
     />
   );
 };

--- a/client/src/pages/game/[displayPosition]/index.page.tsx
+++ b/client/src/pages/game/[displayPosition]/index.page.tsx
@@ -52,17 +52,19 @@ const Game = () => {
     });
 
     const currentEnemyIds = new Set(res.enemies.map((e) => e.id));
-    const killedEnemies = enemies.filter((enemy) => !currentEnemyIds.has(enemy.id));
+    const killedEnemies = enemies.filter(
+      (enemy) =>
+        !currentEnemyIds.has(enemy.id) &&
+        (enemy.pos.x > 1920 * (displayPosition ?? 0) ||
+          enemy.pos.x < 1920 * ((displayPosition ?? 0) + 1))
+    );
 
-    if (killedEnemies.length > 0) {
-      killedEnemies.forEach((enemy) => {
-        const pos = enemy.pos;
-        setEffectPosition((prev) => [
-          ...prev,
-          [{ x: pos.x - ENEMY_HALF_WIDTH, y: pos.y - ENEMY_HALF_WIDTH }],
-        ]);
-      });
-    }
+    const newEffectPosition = killedEnemies.map((enemy) => {
+      return { x: enemy.pos.x - ENEMY_HALF_WIDTH, y: enemy.pos.y - ENEMY_HALF_WIDTH };
+    });
+
+    setEffectPosition((prev) => [...prev.slice(-10), newEffectPosition]);
+
     setPlayers(res.players);
     setEnemies(res.enemies);
     setBullets(res.bullets);

--- a/client/src/pages/game/[displayPosition]/index.page.tsx
+++ b/client/src/pages/game/[displayPosition]/index.page.tsx
@@ -132,7 +132,7 @@ const Game = () => {
               <Text
                 x={player.pos.x - SCREEN_WIDTH * (displayPosition ?? 0)}
                 y={player.pos.y - 80}
-                text={player.name}
+                text={player.name.slice(0, 8)}
                 fontSize={30}
                 fill={'white'}
               />

--- a/server/repository/bulletRepository.ts
+++ b/server/repository/bulletRepository.ts
@@ -41,22 +41,33 @@ export const bulletRepository = {
   },
 
   find: async (bulletId: BulletId): Promise<BulletModel | null> => {
-    const bullet = await prismaClient.bullet.findUnique({
+    const prismaBullet = await prismaClient.bullet.findUnique({
       where: {
         bulletId,
       },
     });
-    return bullet !== null ? toBulletModel(bullet) : null;
+    return prismaBullet !== null ? toBulletModel(prismaBullet) : null;
   },
 
   findAll: async (): Promise<BulletModel[]> => {
-    const bullets = await prismaClient.bullet.findMany();
-    return bullets.map(toBulletModel);
+    const prismaBullet = await prismaClient.bullet.findMany();
+    return prismaBullet.map(toBulletModel);
   },
 
   delete: async (bulletId: BulletId) => {
     await prismaClient.bullet.deleteMany({
       where: { bulletId },
+    });
+  },
+
+  deleteByCreatedTime: async () => {
+    const DELETE_TIME_SEC = 5;
+
+    const boarderTime = new Date();
+    boarderTime.setSeconds(boarderTime.getSeconds() - DELETE_TIME_SEC);
+
+    await prismaClient.bullet.deleteMany({
+      where: { createdAt: { lt: boarderTime } },
     });
   },
 };

--- a/server/usecase/bulletUsecase.ts
+++ b/server/usecase/bulletUsecase.ts
@@ -1,4 +1,5 @@
 import {
+  BULLET_RADIUS,
   DISPLAY_COUNT,
   PLAYER_HALF_WIDTH,
   SCREEN_HEIGHT,
@@ -83,9 +84,13 @@ export const bulletUseCase = {
   getBulletsByDisplay: async (displayNumber: number): Promise<BulletModelWithPos[]> => {
     const bullets = await bulletRepository.findAll();
 
-    const getBulletsByDisplay = bullets.map(entityChangeWithPos).filter((bullet) => {
-      return Math.floor(bullet.pos.x / SCREEN_WIDTH) === displayNumber;
-    }) as BulletModelWithPos[];
+    const getBulletsByDisplay = bullets
+      .map(entityChangeWithPos)
+      .filter(
+        (bullet) =>
+          bullet.pos.x + BULLET_RADIUS > SCREEN_WIDTH * displayNumber &&
+          bullet.pos.x - BULLET_RADIUS < SCREEN_WIDTH * (displayNumber + 1)
+      ) as BulletModelWithPos[];
 
     return getBulletsByDisplay;
   },

--- a/server/usecase/bulletUsecase.ts
+++ b/server/usecase/bulletUsecase.ts
@@ -1,14 +1,7 @@
-import {
-  BULLET_RADIUS,
-  DISPLAY_COUNT,
-  PLAYER_HALF_WIDTH,
-  SCREEN_HEIGHT,
-  SCREEN_WIDTH,
-} from '$/commonConstantsWithClient';
+import { BULLET_RADIUS, PLAYER_HALF_WIDTH, SCREEN_WIDTH } from '$/commonConstantsWithClient';
 import type { UserId } from '$/commonTypesWithClient/branded';
 import { bulletRepository } from '$/repository/bulletRepository';
 import { playerRepository } from '$/repository/playerRepository';
-import { computePosition } from '$/service/computePositions';
 import { entityChangeWithPos } from '$/service/entityChangeWithPos';
 import { bulletIdParser } from '$/service/idParsers';
 import { randomUUID } from 'crypto';
@@ -58,27 +51,7 @@ export const bulletUseCase = {
   },
 
   update: async () => {
-    const currentBulletList = await bulletRepository.findAll();
-
-    const outOfDisplay = (pos: { x: number; y: number }) => {
-      const terms = [
-        pos.x < 0,
-        pos.y < 0,
-        pos.x > DISPLAY_COUNT * SCREEN_WIDTH,
-        pos.y > SCREEN_HEIGHT,
-      ];
-
-      return terms.some(Boolean);
-    };
-
-    await Promise.all(
-      currentBulletList
-        .filter((bullet) => {
-          const pos = computePosition(bullet);
-          return outOfDisplay(pos);
-        })
-        .map(bulletUseCase.delete)
-    );
+    await bulletRepository.deleteByCreatedTime();
   },
 
   getBulletsByDisplay: async (displayNumber: number): Promise<BulletModelWithPos[]> => {

--- a/server/usecase/enemyUsecase.ts
+++ b/server/usecase/enemyUsecase.ts
@@ -1,4 +1,9 @@
-import { DISPLAY_COUNT, SCREEN_HEIGHT, SCREEN_WIDTH } from '$/commonConstantsWithClient';
+import {
+  DISPLAY_COUNT,
+  ENEMY_HALF_WIDTH,
+  SCREEN_HEIGHT,
+  SCREEN_WIDTH,
+} from '$/commonConstantsWithClient';
 import type { EnemyModel, EnemyModelWithPos } from '$/commonTypesWithClient/models';
 import { enemyRepository } from '$/repository/enemyRepository';
 import { computePosition } from '$/service/computePositions';
@@ -83,9 +88,13 @@ export const enemyUseCase = {
 
   getEnemiesByDisplay: async (displayNumber: number): Promise<EnemyModelWithPos[]> => {
     const enemies = await enemyRepository.findAll();
-    const getEnemiesByDisplay = enemies.map(entityChangeWithPos).filter((enemy) => {
-      return Math.floor(enemy.pos.x / SCREEN_WIDTH) === displayNumber;
-    }) as EnemyModelWithPos[];
+    const getEnemiesByDisplay = enemies
+      .map(entityChangeWithPos)
+      .filter(
+        (enemy) =>
+          enemy.pos.x + ENEMY_HALF_WIDTH > SCREEN_WIDTH * displayNumber &&
+          enemy.pos.x - ENEMY_HALF_WIDTH < SCREEN_WIDTH * (displayNumber + 1)
+      ) as EnemyModelWithPos[];
 
     return getEnemiesByDisplay;
   },

--- a/server/usecase/playerUsecase.ts
+++ b/server/usecase/playerUsecase.ts
@@ -1,5 +1,10 @@
 import { randomUUID } from 'crypto';
-import { DISPLAY_COUNT, SCREEN_HEIGHT, SCREEN_WIDTH } from '../commonConstantsWithClient';
+import {
+  DISPLAY_COUNT,
+  PLAYER_HALF_WIDTH,
+  SCREEN_HEIGHT,
+  SCREEN_WIDTH,
+} from '../commonConstantsWithClient';
 import type { UserId } from '../commonTypesWithClient/branded';
 import type { PlayerModel } from '../commonTypesWithClient/models';
 import { playerRepository } from '../repository/playerRepository';
@@ -83,7 +88,10 @@ export const playerUseCase = {
 
   getPlayersByDisplay: async (displayNumber: number) => {
     const isInDisplay = (posX: number, displayNumber: number) => {
-      return Math.floor(posX / SCREEN_WIDTH) === displayNumber;
+      return (
+        posX + PLAYER_HALF_WIDTH > SCREEN_WIDTH * displayNumber &&
+        posX - PLAYER_HALF_WIDTH < SCREEN_WIDTH * (displayNumber + 1)
+      );
     };
     const players = await playerRepository.findAll();
 


### PR DESCRIPTION
## 内容

表示上の名前の長さを制限しました
getbydisplayみたいなのを画面の少し外側まで取得することで滑らかに画面を遷移するようにしました
bulletが秒数で消えるようにしました

## 変更点

- 画面に表示する名前を強制的に8文字にスライス
- 画面の少し外側まで取得
- 爆発エフェクトがいい感じに隠れるようにサイズ調整
- バレットを秒数で消えるように
- 画面外に出ているバレットは描画されずパフォーマンスに影響はほぼないので、一旦秒数だけで消すようにした
