### PR TITLE
playerUsecaseの改善と移動制限幅の調整

### DIFF
--- a/server/commonConstantsWithClient/index.ts
+++ b/server/commonConstantsWithClient/index.ts
@@ -14,6 +14,6 @@ export const SCREEN_HEIGHT = 1080;
 
 export const ALLOW_MOVE_RANGE_MOVE_SPEED = 50;
 
-export const ALLOW_MOVE_RANGE_HALF_WIDTH = 200;
+export const ALLOW_MOVE_RANGE_HALF_WIDTH = 500;
 
 export const PLAYER_MOVE_SPEED = 5;

--- a/server/service/computeAllowedMoveX.ts
+++ b/server/service/computeAllowedMoveX.ts
@@ -14,9 +14,11 @@ export const computeAllowedMoveX = (player: PlayerModel) => {
   const BASE_X = -Math.min(0, SIDE) * SCREEN_WIDTH * DISPLAY_COUNT;
   const DIFF = diffToBaseTimeSec(player);
   const CENTER_X = BASE_X + DIFF * ALLOW_MOVE_RANGE_MOVE_SPEED * SIDE;
-  return minMax(
-    player.pos.x,
-    -ALLOW_MOVE_RANGE_HALF_WIDTH + CENTER_X,
-    ALLOW_MOVE_RANGE_HALF_WIDTH + CENTER_X
+  return Math.round(
+    minMax(
+      player.pos.x,
+      -ALLOW_MOVE_RANGE_HALF_WIDTH + CENTER_X,
+      ALLOW_MOVE_RANGE_HALF_WIDTH + CENTER_X
+    )
   );
 };

--- a/server/usecase/collisionUsecase.ts
+++ b/server/usecase/collisionUsecase.ts
@@ -140,7 +140,7 @@ const isOtherSide = (target1: EntityWithPosModel, target2: EntityWithPosModel) =
 //ANCHOR - checkCollisions
 const checkCollisions = async () => {
   const entities = await Promise.all([
-    playerUseCase.getPlayersAll(),
+    playerUseCase.getAllPlayers(),
     enemyRepository.findAll(),
     bulletRepository.findAll(),
   ]).then(([players, enemies, bullets]) => [...players, ...enemies, ...bullets]);

--- a/server/usecase/playerUsecase.ts
+++ b/server/usecase/playerUsecase.ts
@@ -15,14 +15,16 @@ const isOutOfGameDisplay = (
   displayNumber: number
 ) => {
   const terms = [
-    side === 'left' && pos.x >= SCREEN_WIDTH * displayNumber,
+    side === 'left' && pos.x >= SCREEN_WIDTH * displayNumber - 1,
     side === 'right' && pos.x <= 0,
   ];
   return terms.some(Boolean);
 };
 
 const isInThisDisplay = (posX: number, displayNumber: number) => {
-  return Math.floor(posX / SCREEN_WIDTH) === displayNumber;
+  const lowerBound = SCREEN_WIDTH * displayNumber;
+  const upperBound = SCREEN_WIDTH * (displayNumber + 1);
+  return posX >= lowerBound && posX < upperBound;
 };
 
 const computeScroll = (player: PlayerModel) => {


### PR DESCRIPTION
## 内容

playerUsecaseの改善
移動制限幅を500に

## 変更点

１，関数の分け方をより分かりやすく
２，共通して使う関数を上に分割
３，reduce内でスプレット構文を使うと毎回配列が生成されてしまうので、forEachで同じ配列に追加していくことでパフォーマンス向上
４，関数名を調整

## その他
200は明らかにプレイに支障がでるので500にしましたが最適な値は実際に遊んでみて決める必要があり