### PR TITLE
add: バースト射撃アイテム

### DIFF
--- a/server/api/bullet/controller.ts
+++ b/server/api/bullet/controller.ts
@@ -6,5 +6,5 @@ export default defineController(() => ({
     status: 200,
     body: (await bulletUseCase.getBulletsByDisplay(query.displayNumber)) ?? [],
   }),
-  post: async ({ body }) => ({ status: 200, body: await bulletUseCase.create(body.userId) }),
+  post: async ({ body }) => ({ status: 200, body: await bulletUseCase.shoot(body.userId) }),
 }));

--- a/server/api/bullet/index.ts
+++ b/server/api/bullet/index.ts
@@ -1,6 +1,6 @@
 import type { DefineMethods } from 'aspida';
 import type { UserId } from '../../commonTypesWithClient/branded';
-import type { BulletModel, BulletModelWithPos } from '../../commonTypesWithClient/models';
+import type { BulletModelWithPos } from '../../commonTypesWithClient/models';
 
 export type Methods = DefineMethods<{
   get: {
@@ -13,6 +13,5 @@ export type Methods = DefineMethods<{
     reqBody: {
       userId: UserId;
     };
-    resBody: BulletModel | null;
   };
 }>;

--- a/server/commonConstantsWithClient/index.ts
+++ b/server/commonConstantsWithClient/index.ts
@@ -17,7 +17,3 @@ export const ALLOW_MOVE_RANGE_MOVE_SPEED = 50;
 export const ALLOW_MOVE_RANGE_HALF_WIDTH = 500;
 
 export const DEFAULT_PLAYER_MOVE_SPEED = 5;
-
-export const SPEED_BOOST_DURATION_MS = 15000;
-
-export const SHIELD_DURATION_MS = 5000;

--- a/server/commonConstantsWithClient/item.ts
+++ b/server/commonConstantsWithClient/item.ts
@@ -11,4 +11,8 @@ export const itemsData: Item[] = [
     id: '2',
     name: 'shield',
   },
+  {
+    id: '3',
+    name: 'burst',
+  },
 ];

--- a/server/service/item/itemHandler.ts
+++ b/server/service/item/itemHandler.ts
@@ -1,10 +1,12 @@
 import type { PlayerModel } from 'commonTypesWithClient/models';
-import {
-  DEFAULT_PLAYER_MOVE_SPEED,
-  SHIELD_DURATION_MS,
-  SPEED_BOOST_DURATION_MS,
-} from '../../commonConstantsWithClient';
+import { DEFAULT_PLAYER_MOVE_SPEED } from '../../commonConstantsWithClient';
 import { playerRepository } from '../../repository/playerRepository';
+
+const SPEED_BOOST_DURATION_MS = 15000;
+
+const SHIELD_DURATION_MS = 5000;
+
+const BURST_DURATION_MS = 5000;
 
 interface ItemHandlers {
   [key: string]: (player: PlayerModel) => Promise<void>;
@@ -75,6 +77,40 @@ export const itemHandler: ItemHandlers = {
           }, 500);
         }
       }, SHIELD_DURATION_MS);
+    } catch (error) {
+      console.error('アイテムの使用に失敗しました:', error);
+    }
+  },
+  burst: async (player: PlayerModel) => {
+    const resetBurstEffect = async () => {
+      const currentPlayer = await playerRepository.find(player.id);
+      if (currentPlayer === null) return null;
+      const updatePlayerInfo: PlayerModel = {
+        ...currentPlayer,
+        usingItem: null,
+      };
+      await playerRepository.save(updatePlayerInfo);
+    };
+
+    try {
+      if (player.usingItem !== null) return;
+      const updatePlayerInfo: PlayerModel = {
+        ...player,
+        Items: (player.Items ?? []).slice(1),
+        usingItem: 'burst',
+      };
+      await playerRepository.save(updatePlayerInfo);
+
+      setTimeout(async () => {
+        try {
+          resetBurstEffect();
+        } catch (error) {
+          console.error('リセットに失敗しました:', error);
+          setTimeout(async () => {
+            resetBurstEffect();
+          }, 500);
+        }
+      }, BURST_DURATION_MS);
     } catch (error) {
       console.error('アイテムの使用に失敗しました:', error);
     }

--- a/server/service/shootType.ts
+++ b/server/service/shootType.ts
@@ -1,0 +1,95 @@
+import { PLAYER_HALF_WIDTH } from '$/commonConstantsWithClient';
+import type { UserId } from '$/commonTypesWithClient/branded';
+import type { BulletModel } from '$/commonTypesWithClient/models';
+import { bulletRepository } from '$/repository/bulletRepository';
+import { playerRepository } from '$/repository/playerRepository';
+import { randomUUID } from 'crypto';
+import { computeAllowedMoveX } from './computeAllowedMoveX';
+import { bulletIdParser } from './idParsers';
+import { sideToDirectionX } from './sideToDirectionX';
+
+export const shootType = {
+  normal: async (shooterId: UserId): Promise<BulletModel | null> => {
+    const shooterInfo = await playerRepository.find(shooterId);
+    if (shooterInfo === null) return null;
+
+    const newBullet: BulletModel = {
+      id: bulletIdParser.parse(randomUUID()),
+      direction: {
+        x: sideToDirectionX(shooterInfo.side),
+        y: 0,
+      },
+      createdPos: {
+        x:
+          computeAllowedMoveX(shooterInfo) + PLAYER_HALF_WIDTH * sideToDirectionX(shooterInfo.side),
+        y: shooterInfo.pos.y,
+      },
+      createdAt: Date.now(),
+      side: shooterInfo.side,
+      shooterId,
+    };
+
+    return await bulletRepository.create(newBullet);
+  },
+  burst: async (shooterId: UserId): Promise<BulletModel[] | null> => {
+    const shooterInfo = await playerRepository.find(shooterId);
+    if (shooterInfo === null) return null;
+
+    const newBullets: BulletModel[] = [
+      {
+        id: bulletIdParser.parse(randomUUID()),
+        direction: {
+          x: sideToDirectionX(shooterInfo.side),
+          y: 0,
+        },
+        createdPos: {
+          x:
+            computeAllowedMoveX(shooterInfo) +
+            PLAYER_HALF_WIDTH * sideToDirectionX(shooterInfo.side),
+          y: shooterInfo.pos.y,
+        },
+        createdAt: Date.now(),
+        side: shooterInfo.side,
+        shooterId,
+      },
+      {
+        id: bulletIdParser.parse(randomUUID()),
+        direction: {
+          x: sideToDirectionX(shooterInfo.side),
+          y: 0,
+        },
+        createdPos: {
+          x:
+            computeAllowedMoveX(shooterInfo) +
+            PLAYER_HALF_WIDTH * sideToDirectionX(shooterInfo.side) +
+            50 * sideToDirectionX(shooterInfo.side),
+          y: shooterInfo.pos.y,
+        },
+        createdAt: Date.now(),
+        side: shooterInfo.side,
+        shooterId,
+      },
+      {
+        id: bulletIdParser.parse(randomUUID()),
+        direction: {
+          x: sideToDirectionX(shooterInfo.side),
+          y: 0,
+        },
+        createdPos: {
+          x:
+            computeAllowedMoveX(shooterInfo) +
+            PLAYER_HALF_WIDTH * sideToDirectionX(shooterInfo.side) +
+            100 * sideToDirectionX(shooterInfo.side),
+          y: shooterInfo.pos.y,
+        },
+        createdAt: Date.now(),
+        side: shooterInfo.side,
+        shooterId,
+      },
+    ];
+    newBullets.forEach(async (bullet) => {
+      await bulletRepository.create(bullet);
+    });
+    return newBullets;
+  },
+};

--- a/server/service/shootType.ts
+++ b/server/service/shootType.ts
@@ -35,61 +35,25 @@ export const shootType = {
     const shooterInfo = await playerRepository.find(shooterId);
     if (shooterInfo === null) return null;
 
-    const newBullets: BulletModel[] = [
-      {
-        id: bulletIdParser.parse(randomUUID()),
-        direction: {
-          x: sideToDirectionX(shooterInfo.side),
-          y: 0,
-        },
-        createdPos: {
-          x:
-            computeAllowedMoveX(shooterInfo) +
-            PLAYER_HALF_WIDTH * sideToDirectionX(shooterInfo.side),
-          y: shooterInfo.pos.y,
-        },
-        createdAt: Date.now(),
-        side: shooterInfo.side,
-        shooterId,
+    const newBullets = [0, 50, 100].map((addx) => ({
+      id: bulletIdParser.parse(randomUUID()),
+      direction: {
+        x: sideToDirectionX(shooterInfo.side),
+        y: 0,
       },
-      {
-        id: bulletIdParser.parse(randomUUID()),
-        direction: {
-          x: sideToDirectionX(shooterInfo.side),
-          y: 0,
-        },
-        createdPos: {
-          x:
-            computeAllowedMoveX(shooterInfo) +
-            PLAYER_HALF_WIDTH * sideToDirectionX(shooterInfo.side) +
-            50 * sideToDirectionX(shooterInfo.side),
-          y: shooterInfo.pos.y,
-        },
-        createdAt: Date.now(),
-        side: shooterInfo.side,
-        shooterId,
+      createdPos: {
+        x:
+          computeAllowedMoveX(shooterInfo) +
+          PLAYER_HALF_WIDTH * sideToDirectionX(shooterInfo.side) +
+          addx * sideToDirectionX(shooterInfo.side),
+        y: shooterInfo.pos.y,
       },
-      {
-        id: bulletIdParser.parse(randomUUID()),
-        direction: {
-          x: sideToDirectionX(shooterInfo.side),
-          y: 0,
-        },
-        createdPos: {
-          x:
-            computeAllowedMoveX(shooterInfo) +
-            PLAYER_HALF_WIDTH * sideToDirectionX(shooterInfo.side) +
-            100 * sideToDirectionX(shooterInfo.side),
-          y: shooterInfo.pos.y,
-        },
-        createdAt: Date.now(),
-        side: shooterInfo.side,
-        shooterId,
-      },
-    ];
-    newBullets.forEach(async (bullet) => {
-      await bulletRepository.create(bullet);
-    });
+      createdAt: Date.now(),
+      side: shooterInfo.side,
+      shooterId,
+    }));
+
+    Promise.all(newBullets.map((bullet) => bulletRepository.create(bullet)));
     return newBullets;
   },
 };

--- a/server/usecase/bulletUsecase.ts
+++ b/server/usecase/bulletUsecase.ts
@@ -5,6 +5,7 @@ import { playerRepository } from '$/repository/playerRepository';
 import { computeAllowedMoveX } from '$/service/computeAllowedMoveX';
 import { entityChangeWithPos } from '$/service/entityChangeWithPos';
 import { bulletIdParser } from '$/service/idParsers';
+import { shootType } from '$/service/shootType';
 import { sideToDirectionX } from '$/service/sideToDirectionX';
 import { randomUUID } from 'crypto';
 import type { BulletModel, BulletModelWithPos } from '../commonTypesWithClient/models';
@@ -47,6 +48,16 @@ export const bulletUseCase = {
     };
 
     return await bulletRepository.create(newBullet);
+  },
+
+  shoot: async (shooterId: UserId): Promise<void> => {
+    const shooterInfo = await playerRepository.find(shooterId);
+    if (shooterInfo === null) return;
+    if (shooterInfo.usingItem === 'burst') {
+      await shootType.burst(shooterId);
+      return;
+    }
+    await shootType.normal(shooterId);
   },
 
   delete: async (bulletModel: BulletModel) => {

--- a/server/usecase/bulletUsecase.ts
+++ b/server/usecase/bulletUsecase.ts
@@ -1,13 +1,9 @@
-import { BULLET_RADIUS, PLAYER_HALF_WIDTH, SCREEN_WIDTH } from '$/commonConstantsWithClient';
+import { BULLET_RADIUS, SCREEN_WIDTH } from '$/commonConstantsWithClient';
 import type { UserId } from '$/commonTypesWithClient/branded';
 import { bulletRepository } from '$/repository/bulletRepository';
 import { playerRepository } from '$/repository/playerRepository';
-import { computeAllowedMoveX } from '$/service/computeAllowedMoveX';
 import { entityChangeWithPos } from '$/service/entityChangeWithPos';
-import { bulletIdParser } from '$/service/idParsers';
 import { shootType } from '$/service/shootType';
-import { sideToDirectionX } from '$/service/sideToDirectionX';
-import { randomUUID } from 'crypto';
 import type { BulletModel, BulletModelWithPos } from '../commonTypesWithClient/models';
 
 let intervalId: NodeJS.Timeout | null = null;
@@ -25,29 +21,6 @@ export const bulletUseCase = {
       clearInterval(intervalId);
       intervalId = null;
     }
-  },
-
-  create: async (shooterId: UserId): Promise<BulletModel | null> => {
-    const shooterInfo = await playerRepository.find(shooterId);
-    if (shooterInfo === null) return null;
-
-    const newBullet: BulletModel = {
-      id: bulletIdParser.parse(randomUUID()),
-      direction: {
-        x: sideToDirectionX(shooterInfo.side),
-        y: 0,
-      },
-      createdPos: {
-        x:
-          computeAllowedMoveX(shooterInfo) + PLAYER_HALF_WIDTH * sideToDirectionX(shooterInfo.side),
-        y: shooterInfo.pos.y,
-      },
-      createdAt: Date.now(),
-      side: shooterInfo.side,
-      shooterId,
-    };
-
-    return await bulletRepository.create(newBullet);
   },
 
   shoot: async (shooterId: UserId): Promise<void> => {


### PR DESCRIPTION
## 内容

3連バースト射撃アイテムを追加

## 変更点
- 3連続で射撃するバースト射撃アイテムを追加
  - 弾の生成を分離して汎用化



## スクリーンショット・動画など


https://github.com/INIAD-Developers/Gradius-2023/assets/36080294/e9b01418-359c-4af7-b8fb-c370e188b9aa



